### PR TITLE
docs: macOS mDNSResponder NXDOMAIN cache after destroy + reapply

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -59,6 +59,28 @@ The AWS Load Balancer Controller registers a cluster-wide `MutatingWebhookConfig
 
 The module serializes KEDA on `helm_release.lbc` (which has `wait = true`), so LBC pods are guaranteed Ready before KEDA installs. If you hit this on an older revision of the module, simply re-run `terraform apply` — by the time the second apply starts, LBC is up and KEDA installs cleanly.
 
+## Smoke test reports `HTTP 000` after a recent destroy + re-apply
+
+**Symptom**
+
+`tests/scripts/smoke-test.sh` fails the HTTP health, redirect, and API checks with `HTTP 000` against the n8n URL. Direct `dig n8n.example.com` resolves correctly, but `curl https://n8n.example.com/healthz` exits with code 6 (`CURLE_COULDNT_RESOLVE_HOST`).
+
+**Cause (macOS)**
+
+`mDNSResponder` cached the NXDOMAIN response from the previous deployment's destroy phase and is serving it for 5–15 minutes even after Terraform re-created the Route 53 alias record. `dig` and `host` bypass `mDNSResponder`; `curl`, browsers, and anything else using `getaddrinfo()` do not.
+
+This only reproduces when the same FQDN is reused across consecutive `apply` → `destroy` → `apply` cycles on the same workstation, which is common during iterative development of this module but unusual in production.
+
+**Fix**
+
+Flush the macOS DNS cache:
+
+```bash
+sudo killall -HUP mDNSResponder
+```
+
+Or wait for the negative cache to age out (typically 5–15 minutes). To avoid the issue entirely, use a fresh subdomain per deployment.
+
 ## `terraform destroy` hangs on namespace or finalizers
 
 See [destroy-cleanup.md](./destroy-cleanup.md).

--- a/tests/scripts/smoke-test.sh
+++ b/tests/scripts/smoke-test.sh
@@ -542,6 +542,12 @@ else
     pass "/healthz returned HTTP $healthz_status"
   elif [[ "$healthz_status" == "000" ]]; then
     fail "/healthz — connection failed (timeout or DNS error)"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      info "On macOS, a recent destroy + re-apply against the same FQDN often"
+      info "leaves mDNSResponder serving the destroy-phase NXDOMAIN for 5-15 min."
+      info "Fix: sudo killall -HUP mDNSResponder"
+      info "Details: docs/troubleshooting.md → 'Smoke test reports HTTP 000'"
+    fi
   else
     fail "/healthz returned HTTP $healthz_status (expected 200)"
   fi


### PR DESCRIPTION
## Summary

- Document the macOS `mDNSResponder` NXDOMAIN-caching gotcha that surfaces during iterative `apply` → `destroy` → `apply` cycles against the same FQDN. The smoke test reports `HTTP 000` even though Route 53 has already re-created the alias record and `dig` resolves correctly.
- Section added to `docs/troubleshooting.md` in the existing **Symptom / Cause / Fix** style, placed before the `terraform destroy` cross-doc pointer to keep in-page entries grouped.
- One-line fix (`sudo killall -HUP mDNSResponder`), plus the alternative of using a fresh subdomain per deployment.

Reproducibly hit during PR #4 validation; filing as a follow-up because Issues are disabled on this repo.

## Test plan

- [ ] Render `docs/troubleshooting.md` and confirm the new section formats correctly (headings, code block, arrows).
- [ ] Skim that no other entries were unintentionally moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)