### PR TITLE
Harden Aurora cluster defaults in examples/large/

### DIFF
--- a/examples/large/README.md
+++ b/examples/large/README.md
@@ -131,6 +131,7 @@ kubectl rollout status deployment/n8n-worker deployment/n8n-webhook-processor \
 
 | Name | Type |
 | ---- | ---- |
+| [aws_cloudwatch_log_group.aurora_postgresql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_db_subnet_group.aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_rds_cluster.n8n](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |

--- a/examples/large/aurora.tf
+++ b/examples/large/aurora.tf
@@ -62,11 +62,39 @@ resource "aws_rds_cluster" "n8n" {
   # throughput. Breaks even vs standard Aurora at ~25% I/O utilization.
   storage_type = "aurora-iopt1"
 
+  # Hardening defaults. Aurora leaves storage_encrypted = false unless set
+  # explicitly (CKV_AWS_96 — "Ensure all data stored in Aurora is securely
+  # encrypted at rest"), which is Registry table-stakes for any new RDS-family
+  # resource. IAM database authentication (CKV_AWS_162) and postgresql log
+  # export to CloudWatch (CKV_AWS_354) round out the baseline so a new resource
+  # does not regress curated findings. CKV_AWS_327 (encrypt with a customer
+  # managed KMS key rather than the AWS-managed `aws/rds` key) is intentionally
+  # deferred — tracked as a follow-up alongside the still-failing instance-
+  # level Aurora findings (353 / 226 / 118) and CKV_AWS_313 / CKV_AWS_139.
+  storage_encrypted                   = true
+  iam_database_authentication_enabled = true
+  enabled_cloudwatch_logs_exports     = ["postgresql"]
+
   backup_retention_period = 7
   skip_final_snapshot     = true
   deletion_protection     = false
 
+  # Ensure the log group exists (with our retention) before RDS would otherwise
+  # auto-create it at "Never expire".
+  depends_on = [aws_cloudwatch_log_group.aurora_postgresql]
+
   tags = merge(local.common_tags, { Name = "${var.cluster_name}-aurora" })
+}
+
+# CloudWatch Log Group for the postgresql log export. Created explicitly so we
+# own retention (CKV_AWS_338); without this resource, RDS auto-creates the group
+# with "Never expire" retention. CMK encryption on the log group (CKV_AWS_158)
+# is intentionally deferred alongside the cluster-level CKV_AWS_327 follow-up.
+resource "aws_cloudwatch_log_group" "aurora_postgresql" {
+  name              = "/aws/rds/cluster/${var.cluster_name}-aurora/postgresql"
+  retention_in_days = 365
+
+  tags = merge(local.common_tags, { Name = "${var.cluster_name}-aurora-postgresql-logs" })
 }
 
 resource "aws_rds_cluster_instance" "writer" {


### PR DESCRIPTION
## Summary

- Enables three baseline defaults on `aws_rds_cluster.n8n` in `examples/large/aurora.tf`:
  - `storage_encrypted = true` (AWS-managed KMS; Aurora leaves this `false` unless set explicitly)
  - `iam_database_authentication_enabled = true`
  - `enabled_cloudwatch_logs_exports = ["postgresql"]`

## What this does *not* do

The originating follow-up doc cited `CKV_AWS_133` and `CKV_AWS_327` as the IDs this would clear. After actually running checkov locally against `examples/large/`:

- **`CKV_AWS_133`** does not apply to `aws_rds_cluster` (it's an RDS-*instance* backup-retention check, which the module's main `aws_db_instance.n8n` already satisfies).
- **`CKV_AWS_327`** wants a Customer Managed KMS Key (`kms_key_id`), not just `storage_encrypted = true`. This PR uses the AWS-managed default and therefore does **not** clear `_327`.

Both findings are tracked as separate follow-ups along with the other still-open Aurora-cluster + cluster-instance findings:

| Resource | Check | What's needed |
|---|---|---|
| `aws_rds_cluster.n8n` | `CKV_AWS_327` | New `aws_kms_key` + `kms_key_id` on the cluster (~$1/mo per CMK) |
| `aws_rds_cluster.n8n` | `CKV_AWS_313` | `copy_tags_to_snapshots = true` (one-liner) |
| `aws_rds_cluster.n8n` | `CKV_AWS_139` | `deletion_protection = true` — intentionally `false` for example teardown; candidate for an annotated `# checkov:skip` |
| `aws_rds_cluster_instance.writer` / `.reader` | `CKV_AWS_353` | `performance_insights_enabled = true` (~\$7/mo per instance) |
| `aws_rds_cluster_instance.writer` / `.reader` | `CKV_AWS_226` | `auto_minor_version_upgrade = true` (one-liner each) |
| `aws_rds_cluster_instance.writer` / `.reader` | `CKV_AWS_118` | Enhanced monitoring (new IAM role, ongoing CloudWatch cost) |

## Test plan

- [x] `terraform fmt -check examples/large/aurora.tf`
- [x] `terraform init -backend=false && terraform validate` in `examples/large/`
- [x] `terraform test -verbose` in `examples/large/` (2 passed, 0 failed)
- [x] `checkov --directory examples/large --framework terraform` local scan: the three originally-targeted attributes are now present; `CKV_AWS_327` still fails for the CMK-vs-AWS-managed-KMS reason called out above.
- [ ] Confirm CI checkov output mirrors the local result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)