### PR TITLE
Enable Aurora Performance Insights (CKV_AWS_353)

### DIFF
--- a/examples/large/aurora.tf
+++ b/examples/large/aurora.tf
@@ -67,14 +67,15 @@ resource "aws_rds_cluster" "n8n" {
   # explicitly (CKV_AWS_96 — "Ensure all data stored in Aurora is securely
   # encrypted at rest"), which is Registry table-stakes for any new RDS-family
   # resource. IAM database authentication (CKV_AWS_162) and postgresql log
-  # export to CloudWatch (CKV_AWS_354) round out the baseline so a new resource
+  # export to CloudWatch (CKV_AWS_324) round out the baseline so a new resource
   # does not regress curated findings. copy_tags_to_snapshot (CKV_AWS_313)
   # propagates the existing tag set onto automated + manual snapshots.
   # CKV_AWS_327 (encrypt with a customer-managed KMS key rather than the
   # AWS-managed `aws/rds` key) is intentionally deferred — tracked as a
   # follow-up alongside the other still-failing Aurora findings: instance-
-  # level CKV_AWS_353 / CKV_AWS_118, cluster-level CKV_AWS_139, and log-group
-  # CKV_AWS_158.
+  # level CKV_AWS_354 (PI CMK) / CKV_AWS_118 (enhanced monitoring), cluster-
+  # level CKV_AWS_139 (deletion_protection — see checkov:skip annotation),
+  # and log-group CKV_AWS_158.
   storage_encrypted                   = true
   iam_database_authentication_enabled = true
   enabled_cloudwatch_logs_exports     = ["postgresql"]
@@ -123,6 +124,14 @@ resource "aws_rds_cluster_instance" "writer" {
   # the instances, since AWS upgrades them in lockstep with the cluster.
   auto_minor_version_upgrade = true
 
+  # CKV_AWS_353: Performance Insights with the default 7-day retention window
+  # is included in the AWS free tier. Pinning the retention period explicitly
+  # prevents silent cost regression if AWS changes the default. CKV_AWS_354 (PI
+  # data encrypted with a customer-managed KMS key) is intentionally deferred
+  # — tracked alongside the cluster-level CKV_AWS_327 CMK follow-up.
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 7
+
   lifecycle {
     ignore_changes = [engine_version]
   }
@@ -141,6 +150,14 @@ resource "aws_rds_cluster_instance" "reader" {
   # window. See the cluster's lifecycle.ignore_changes above — it also covers
   # the instances, since AWS upgrades them in lockstep with the cluster.
   auto_minor_version_upgrade = true
+
+  # CKV_AWS_353: Performance Insights with the default 7-day retention window
+  # is included in the AWS free tier. Pinning the retention period explicitly
+  # prevents silent cost regression if AWS changes the default. CKV_AWS_354 (PI
+  # data encrypted with a customer-managed KMS key) is intentionally deferred
+  # — tracked alongside the cluster-level CKV_AWS_327 CMK follow-up.
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 7
 
   lifecycle {
     ignore_changes = [engine_version]


### PR DESCRIPTION
## Summary

Clears `CKV_AWS_353` on both `aws_rds_cluster_instance.writer` and `aws_rds_cluster_instance.reader` in `examples/large/aurora.tf` by setting `performance_insights_enabled = true` plus an explicit `performance_insights_retention_period = 7`.

## Cost correction

The original `EKS Followup Items` doc flagged this as a "~$14/mo ongoing cost" item. That was wrong: AWS Performance Insights with the default 7-day retention window is included in the **free tier** on every Aurora and RDS engine. The cost only kicks in when retention is extended past 7 days (Long Term Retention, billed per vCPU per month).

This PR therefore lands as a **zero-cost hygiene improvement** with the same risk profile as PR #9 (snapshot tags + minor upgrades), not a judgment-call cost decision.

## Why set `performance_insights_retention_period` explicitly

Two reasons to set it alongside the enable flag rather than relying on the default:

1. **Free-tier commitment is visible at the resource level.** A reader can see immediately that this deployment is on free-tier PI without cross-referencing AWS docs.
2. **No silent regression risk.** If AWS ever changes the default retention period to a billable value, an explicit `= 7` prevents the deployment from quietly stepping into ongoing costs on the next plan/apply.

## New finding surfaced: `CKV_AWS_354`

Enabling Performance Insights without specifying `performance_insights_kms_key_id` causes checkov to fire **CKV_AWS_354** (*"Ensure RDS Performance Insights are encrypted using KMS CMKs"*) on both instances. AWS encrypts PI data with the `aws/rds` AWS-managed key by default when no key is supplied; clearing 354 requires creating an `aws_kms_key` resource and wiring it through `performance_insights_kms_key_id`.

This is the same Customer Managed KMS Key work already tracked for **`CKV_AWS_327`** (cluster-level CMK encryption). Both can be resolved by a single follow-up PR that introduces an Aurora KMS key and wires it into:

- `aws_rds_cluster.n8n.kms_key_id` (clears `CKV_AWS_327`)
- `aws_rds_cluster_instance.writer.performance_insights_kms_key_id` (clears `CKV_AWS_354`)
- `aws_rds_cluster_instance.reader.performance_insights_kms_key_id` (clears `CKV_AWS_354`)

Bundling those into one CMK PR is the right call because they share the resource being created.

## Test plan

- [x] `terraform fmt -check examples/large/aurora.tf`
- [x] `terraform init -backend=false && terraform validate` in `examples/large/`
- [x] `terraform test -verbose` in `examples/large/` (2 passed, 0 failed)
- [x] `checkov --directory examples/large --framework terraform --check CKV_AWS_353` reports **2 passed, 0 failed**
- [x] Confirmed `CKV_AWS_354` is the new follow-up (PI-CMK path), documented above
- [ ] Confirm CI checkov output mirrors the local result

🤖 Generated with [Claude Code](https://claude.com/claude-code)