### PR TITLE
Enable RDS Enhanced Monitoring on Aurora writer + reader (CKV_AWS_118)

### DIFF
--- a/examples/large/README.md
+++ b/examples/large/README.md
@@ -149,6 +149,8 @@ The S3 `force_destroy` setting lives in the module and is not currently exposed 
 | [aws_cloudwatch_log_group.aurora_postgresql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_db_subnet_group.aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
+| [aws_iam_role.rds_enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.rds_enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_rds_cluster.n8n](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.reader](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_rds_cluster_instance.writer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |

--- a/examples/large/aurora.tf
+++ b/examples/large/aurora.tf
@@ -70,12 +70,12 @@ resource "aws_rds_cluster" "n8n" {
   # export to CloudWatch (CKV_AWS_324) round out the baseline so a new resource
   # does not regress curated findings. copy_tags_to_snapshot (CKV_AWS_313)
   # propagates the existing tag set onto automated + manual snapshots.
-  # CKV_AWS_327 (encrypt with a customer-managed KMS key rather than the
-  # AWS-managed `aws/rds` key) is intentionally deferred — tracked as a
-  # follow-up alongside the other still-failing Aurora findings: instance-
-  # level CKV_AWS_354 (PI CMK) / CKV_AWS_118 (enhanced monitoring), cluster-
-  # level CKV_AWS_139 (deletion_protection — see checkov:skip annotation),
-  # and log-group CKV_AWS_158.
+  # All remaining deferred findings are CMK-encryption work tracked as a
+  # single follow-up: cluster-level CKV_AWS_327, instance-level CKV_AWS_354
+  # (PI CMK on writer + reader), and log-group CKV_AWS_158 — the same
+  # aws_kms_key resource will satisfy all three. CKV_AWS_139 (deletion
+  # protection) is the only other unresolved finding and is intentionally
+  # skipped via a checkov:skip annotation on the cluster (see below).
   storage_encrypted                   = true
   iam_database_authentication_enabled = true
   enabled_cloudwatch_logs_exports     = ["postgresql"]
@@ -112,6 +112,33 @@ resource "aws_cloudwatch_log_group" "aurora_postgresql" {
   tags = merge(local.common_tags, { Name = "${var.cluster_name}-aurora-postgresql-logs" })
 }
 
+# ── Enhanced Monitoring IAM role ──────────────────────────────────────────────
+# RDS Enhanced Monitoring writes OS-level metrics (CPU steal, swap, per-process
+# activity, IOPS depth) to CloudWatch Logs at a configurable cadence. 60-second
+# granularity is the AWS-recommended default for production and the cheapest
+# billable interval; sub-60s costs scale with CloudWatch Logs ingestion volume.
+# Shared by writer + reader.
+
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name = "${var.cluster_name}-rds-monitoring"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "monitoring.rds.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(local.common_tags, { Name = "${var.cluster_name}-rds-monitoring" })
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
 resource "aws_rds_cluster_instance" "writer" {
   identifier         = "${var.cluster_name}-writer"
   cluster_identifier = aws_rds_cluster.n8n.id
@@ -131,6 +158,11 @@ resource "aws_rds_cluster_instance" "writer" {
   # — tracked alongside the cluster-level CKV_AWS_327 CMK follow-up.
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
+
+  # CKV_AWS_118: RDS Enhanced Monitoring at the 60-second AWS-recommended
+  # cadence. See the aws_iam_role.rds_enhanced_monitoring resource above.
+  monitoring_interval = 60
+  monitoring_role_arn = aws_iam_role.rds_enhanced_monitoring.arn
 
   lifecycle {
     ignore_changes = [engine_version]
@@ -158,6 +190,11 @@ resource "aws_rds_cluster_instance" "reader" {
   # — tracked alongside the cluster-level CKV_AWS_327 CMK follow-up.
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
+
+  # CKV_AWS_118: RDS Enhanced Monitoring at the 60-second AWS-recommended
+  # cadence. See the aws_iam_role.rds_enhanced_monitoring resource above.
+  monitoring_interval = 60
+  monitoring_role_arn = aws_iam_role.rds_enhanced_monitoring.arn
 
   lifecycle {
     ignore_changes = [engine_version]


### PR DESCRIPTION
## Summary

Clears `CKV_AWS_118` on both `aws_rds_cluster_instance.writer` and `aws_rds_cluster_instance.reader` in `examples/large/aurora.tf` by enabling Enhanced Monitoring with a 60-second collection interval and a shared IAM role.

## What changed

- New `aws_iam_role.rds_enhanced_monitoring` with `monitoring.rds.amazonaws.com` as the trust principal.
- The role attaches the AWS-managed `AmazonRDSEnhancedMonitoringRole` policy so we do not maintain a hand-rolled CloudWatch Logs permission set.
- Both cluster instances get `monitoring_interval = 60` + `monitoring_role_arn = aws_iam_role.rds_enhanced_monitoring.arn`.
- `examples/large/README.md` regenerated via `terraform-docs` to surface the two new IAM resources in the auto-generated resource table.

## Why 60-second granularity

| Interval | When to use | Cost profile |
|---|---|---|
| **60s** (this PR) | AWS-recommended default for production observability | Cheapest billable interval; ~$0.50–$1 per instance per month at typical workload |
| 30s / 15s | Tightening signal during a specific incident | Scales linearly with CloudWatch Logs ingestion volume |
| 5s / 1s | Targeted debugging of sub-minute spikes only | Can reach $5–$7 per instance per month, mostly wasted at steady state |

60s strikes the right balance for a reference deployment: it satisfies `CKV_AWS_118`, gives operators the OS-level metrics (CPU steal, swap, per-process activity, IOPS depth) that vanilla CloudWatch metrics do not surface, and keeps ongoing cost in the noise floor of a deployment whose monthly base is already in five figures.

## Why inline `jsonencode()` instead of `aws_iam_policy_document`

Two reasons:

1. **Module convention.** The module's `iam.tf` uses inline `jsonencode()` for every trust policy (LBC role, cluster autoscaler role, etc.). Matching that keeps the pattern uniform across the codebase.
2. **Plan-time test compatibility.** `data.aws_iam_policy_document` returns mocked content under the test suite's mocked AWS provider, which fails `aws_iam_role.assume_role_policy` JSON validation. Inline `jsonencode()` has no data-source dependency to mock.

The two approaches are functionally identical at apply time; the cosmetic difference is the only thing in scope here.

## Test plan

- [x] `terraform fmt -check examples/large/aurora.tf`
- [x] `terraform init -backend=false && terraform validate` in `examples/large/`
- [x] `terraform test -verbose` in `examples/large/` (2 passed, 0 failed)
- [x] `checkov --directory examples/large --framework terraform --check CKV_AWS_118` reports **2 passed, 0 failed**
- [x] `terraform-docs --output-check examples/large` passes after regeneration
- [ ] Confirm CI checkov output mirrors the local result

🤖 Generated with [Claude Code](https://claude.com/claude-code)