### PR TITLE
Validate db_host and db_password at plan time when create_database = false

### DIFF
--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -148,6 +148,35 @@ run "external_db_skips_rds_instance" {
   }
 }
 
+# Cross-variable validation: when the caller opts into an external database
+# (create_database = false), both db_host and db_password are required at plan
+# time. Without these the failure would surface deep inside the n8n Helm release
+# at apply time, after EKS and the database resources have already been built.
+
+run "external_db_missing_host_fails_validation" {
+  command = plan
+
+  variables {
+    create_database = false
+    db_password     = "external-db-password"
+    # db_host intentionally unset
+  }
+
+  expect_failures = [var.db_host]
+}
+
+run "external_db_missing_password_fails_validation" {
+  command = plan
+
+  variables {
+    create_database = false
+    db_host         = "aurora-cluster.cluster-abc123.us-east-1.rds.amazonaws.com"
+    # db_password intentionally unset
+  }
+
+  expect_failures = [var.db_password]
+}
+
 run "redis_private_and_sized" {
   command = plan
 

--- a/variables.tf
+++ b/variables.tf
@@ -457,6 +457,11 @@ variable "db_host" {
   description = "External database host. Required when create_database = false. Ignored otherwise. Use this to pass in an Amazon Aurora cluster endpoint or any external PostgreSQL host."
   type        = string
   default     = null
+
+  validation {
+    condition     = var.create_database || var.db_host != null
+    error_message = "db_host is required when create_database = false."
+  }
 }
 
 variable "db_password" {
@@ -464,6 +469,11 @@ variable "db_password" {
   type        = string
   default     = null
   sensitive   = true
+
+  validation {
+    condition     = var.create_database || var.db_password != null
+    error_message = "db_password is required when create_database = false."
+  }
 }
 
 variable "db_postgresdb_pool_size" {


### PR DESCRIPTION
## Summary

Adds cross-variable `validation` blocks to `var.db_host` and `var.db_password` in `variables.tf` so a caller who opts into the external-database path (`create_database = false`) but forgets to supply both required inputs gets a plan-time error rather than an apply-time crash deep inside the n8n Helm release.

## Why this is plan-time, not apply-time

Without these validations, the failure mode is:

1. Caller sets `create_database = false` (e.g. they intend to use an existing Aurora cluster)
2. They forget to also supply `db_host` and/or `db_password`
3. `terraform plan` succeeds — no resource references `var.db_host` until the `n8n.tf` Helm release stage
4. `terraform apply` runs for ~30 minutes provisioning EKS and the database resources
5. The `helm_release.n8n` step fails with a confusing error about the missing connection string
6. The operator now has to either destroy the half-built stack or fix the inputs and re-apply

Catching the misconfiguration at plan time (before *any* resource is created) saves the operator a destroy cycle and the expensive EKS / Aurora provisioning steps. This is exactly the case cross-variable validation in Terraform 1.9+ exists for.

## Implementation

`versions.tf` already pins `terraform >= 1.9`, so cross-variable references in `validation` blocks are available without bumping the constraint. The two new validations both read `var.create_database`:

```hcl
validation {
  condition     = var.create_database || var.db_host != null
  error_message = "db_host is required when create_database = false."
}
```

Boolean short-circuit semantics mean the validations no-op when `create_database = true` (the default), so they impose no constraint on the happy path.

## Test coverage

Two new plan-time tests in `tests/defaults.tftest.hcl` exercise the failure mode using `expect_failures`:

- `external_db_missing_host_fails_validation` — sets `create_database = false` + `db_password`, leaves `db_host` unset, asserts the validation fires.
- `external_db_missing_password_fails_validation` — symmetric: sets `create_database = false` + `db_host`, leaves `db_password` unset.

The existing `external_db_skips_rds_instance` happy-path test continues to pass; it sets both vars so the validations do not fire.

## Test plan

- [x] `terraform fmt -check variables.tf tests/defaults.tftest.hcl`
- [x] `terraform validate` from module root
- [x] `terraform test -verbose` from module root — **15 passed, 0 failed** (was 13 passed; the two new tests both pass)
- [x] `terraform-docs --output-check .` clean (validation blocks do not surface in the rendered table, no README drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)