### PR TITLE
Document Aurora password URL-reserved character contract

### DIFF
--- a/examples/large/aurora.tf
+++ b/examples/large/aurora.tf
@@ -11,8 +11,30 @@
 # The module-managed RDS instance is skipped (db_host is set in main.tf).
 
 resource "random_password" "aurora" {
-  length           = 24
-  special          = true
+  length  = 24
+  special = true
+
+  # override_special intentionally includes URL-reserved characters (`:` `?`
+  # `#` `&` `=` `+` `(` `)` `*` `!` `$` `[` `]`, plus `%` which is the URI
+  # percent-encoding escape character itself). These are safe in the current
+  # data flow:
+  #
+  #   random_password.aurora.result
+  #     → master_password on aws_rds_cluster.n8n (AWS API, not URL)
+  #     → kubernetes_secret.pgbouncer DB_PASSWORD field (binary data)
+  #     → DB_PASSWORD env var on the pgbouncer container
+  #     → pgbouncer's userlist.txt (newline-delimited, not URL-parsed)
+  #     → module.n8n.db_password (passed verbatim to n8n via env)
+  #
+  # None of those paths parse the password as a URI, so the broader character
+  # set gives stronger entropy without operational risk today.
+  #
+  # If a future maintainer plumbs this password into a `postgres://` connection
+  # URI (for example, exposing a JDBC URL output or wiring it through a tool
+  # that builds the URL itself), the URL-reserved characters must either be
+  # percent-encoded by the caller or trimmed from this override_special set.
+  # The URL-safe subset of the current characters is just `-_`; anything else
+  # would need encoding.
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 


### PR DESCRIPTION
## Summary

Adds an inline comment block to `random_password.aurora` in `examples/large/aurora.tf` documenting the URL-reserved characters in its `override_special` set, the current data flow (which is URL-safe), and the contract a future maintainer must honour if they ever plumb this password through a `postgres://` connection URI.

No behaviour change — the `override_special` value is unchanged.

## Why

`override_special = "!#$%&*()-_=+[]{}<>:?"` deliberately picks a broad special-character set for entropy. Many of those characters are URL-reserved per RFC 3986:

| Char | RFC 3986 role |
|---|---|
| `:` | userinfo / host:port separator |
| `?` | query string marker |
| `#` | fragment identifier |
| `&` | query parameter separator |
| `=` | query value separator |
| `+` | sub-delim (and also `' '` in form-encoded contexts) |
| `(` `)` `*` `!` `$` | sub-delims |
| `[` `]` | IPv6 host brackets |
| `%` | the percent-encoding escape character itself |

Today this is **safe** because no consumer parses the password as a URI:

```
random_password.aurora.result
  → aws_rds_cluster.n8n.master_password    (AWS API field, not URL)
  → kubernetes_secret.pgbouncer.DB_PASSWORD (opaque bytes)
  → DB_PASSWORD env var on pgbouncer container
  → pgbouncer's userlist.txt                (newline-delimited)
  → module.n8n.db_password                  (env var, not URL)
```

The risk is purely **latent**. If someone later exposes the password through a JDBC connection URL output, wires it into a CLI that builds `postgres://user:pass@host/db` itself, or pastes the raw value into a tool that expects a URL, the connection string will be broken in a way that produces no obvious error message — just authentication failures or parse errors a long way from the password generator.

## What the comment captures

1. The complete list of URL-reserved characters currently included.
2. The five-hop data-flow diagram so a maintainer can quickly verify nothing has been added that does URL parsing.
3. The maintainer contract: if the password starts flowing through a URI, either percent-encode at the consumer or trim the URL-reserved characters from `override_special`.
4. The URL-safe subset of the current characters (just `-_`), so a future change knows exactly which characters need trimming if the trim path is chosen, without having to re-derive the RFC 3986 analysis.

## Why not just trim the URL-reserved characters now

Two reasons:

1. **Real entropy cost.** The current set has 19 special characters. Trimming to URL-safe leaves 2 (`-_`), which materially weakens the random space against an offline attacker. With the password never touching a URI in practice, the trim would be a regression-for-a-hypothetical.
2. **No deployed consumer that wants it.** This password lives entirely inside the cluster network in env vars and a Kubernetes Secret. Trimming for an audience that does not exist invites the future "why is our password so weak?" question later.

If a `postgres://`-consuming path is actually added in the future, that PR is the right place to make the entropy-vs-format trade-off explicitly.

## Test plan

- [x] `terraform fmt -check examples/large/aurora.tf`
- [x] `terraform validate` in `examples/large/`
- [x] `terraform test -verbose` in `examples/large/` (2 passed, 0 failed; no behaviour change, the test suite would have caught any regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)