### PR TITLE
Annotate CKV_AWS_293 skip on module's RDS

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -116,6 +116,7 @@ moved {
 }
 
 resource "aws_db_instance" "n8n" {
+  # checkov:skip=CKV_AWS_293:Deletion protection is intentionally left at the provider default (false) so `terraform destroy` works cleanly during evaluation and example teardown. Flip to `true` for production. See examples/*/README.md → "Production considerations" for the full set of teardown-friendly defaults to review before promoting any example to production.
   count = var.create_database ? 1 : 0
 
   identifier        = "n8n-postgres-${local.cluster_name}"


### PR DESCRIPTION
## Summary

Adds an annotated `# checkov:skip=CKV_AWS_293` comment on `aws_db_instance.n8n` in `database.tf`. This mirrors PR #10's `CKV_AWS_139` skip on the Aurora cluster, applied to the module's own RDS instance so the rationale lands at the resource that the four module-RDS-using examples (`small` / `complete`, `medium`, `cloudflare`, `godaddy`) instantiate.

No behaviour change — `deletion_protection` continues to ride the provider default of `false`.

## Why skip, not flip

Same argument as PR #10:

- The four examples that use this resource (small, medium, cloudflare, godaddy) are reference deployments explicitly intended to be deployed then destroyed. Each example's `README.md` documents the apply / destroy flow.
- Flipping `deletion_protection = true` actively breaks that flow: every operator running through one of these examples would hit a `DeletionProtection enabled` error on `terraform destroy`, have to edit the module's `.tf`, re-apply, then destroy. That is a worse onboarding experience in service of a check that does not apply to the example's actual use case.
- `CKV_AWS_293` exists for **production** RDS instances where accidental deletion is a real risk. A reference module-managed instance in an example is the canonical case where suppressing the check (with documented reasoning) is correct, not regressing it.

The annotation **carries information** a flip wouldn't: it documents that the default was chosen deliberately and points at the existing **"Production considerations"** sections (added in PR #10) for the full set of teardown-friendly defaults to review before promoting any example to production.

## Why no resource attribute change

The skip annotation is recognised even when the underlying attribute is unset — the annotation suppresses the check at the resource level, not on a specific attribute. Local checkov reports:

```
checkov --directory . --framework terraform --check CKV_AWS_293
Passed checks: 0, Failed checks: 0, Skipped checks: 5
```

The 5 skips are: the module's `aws_db_instance.n8n` plus one per example that instantiates the module's RDS path (small / complete, medium, cloudflare, godaddy). `examples/large/` doesn't show because it sets `create_database = false` and uses Aurora.

Leaving `deletion_protection` unset (rather than explicitly setting it to `false`) keeps the production-considerations table in each example's README accurate ("`false` (provider default; not set)").

## Test plan

- [x] `terraform fmt -check database.tf`
- [x] `terraform validate` from module root
- [x] `terraform test -verbose` from module root — **13 passed, 0 failed** (no behaviour change; existing assertions still pass)
- [x] `checkov --check CKV_AWS_293 --directory . --framework terraform` reports **0 failed, 5 skipped**
- [ ] Confirm CI checkov output mirrors the local result

🤖 Generated with [Claude Code](https://claude.com/claude-code)