### PR TITLE
feat: bump AWS (~> 6.0) and Helm (~> 3.0) providers and default n8n chart to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ this project adheres to the stability contract in
   `terraform plan -refresh-only` followed by `terraform apply -refresh-only` to
   settle state before applying further changes. Callers who must remain on AWS
   provider 5.x should pin this module to `~> 0.1`.
+- **Helm provider requirement bumped to `~> 3.0`** (was `~> 2.12`). Helm
+  provider 3.0 is a Plugin Framework rewrite. The `set` blocks on the bundled
+  controller releases (AWS Load Balancer Controller, Cluster Autoscaler,
+  metrics-server) were converted to the new `set = [...]` list syntax, and the
+  example `provider "helm"` blocks now use the `kubernetes = { ... }` object
+  form. Upgrade note: drift detection is stricter in 3.x, so the first
+  `terraform plan` after upgrading may show in-place diffs on existing
+  `helm_release` resources. Callers who must remain on Helm provider 2.x should
+  pin this module to `~> 0.1`.
 
 ## [0.1.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ this project adheres to the stability contract in
   `terraform plan` after upgrading may show in-place diffs on existing
   `helm_release` resources. Callers who must remain on Helm provider 2.x should
   pin this module to `~> 0.1`.
+- **Default `n8n_chart_version` bumped to `1.10.0`** (was `1.4.0`). Applying
+  this default change cycles the n8n pods. Pin `n8n_chart_version` to stay on a
+  specific chart release. Validated by a real apply of examples/small plus the
+  post-deploy smoke test.
 
 ## [0.1.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ this project adheres to the stability contract in
   are set while the master switch is off. When disabled (the default) no
   `N8N_LOG_STREAMING_*` env vars are emitted.
 
+### Changed
+
+- **AWS provider requirement bumped to `~> 6.0`** (was `~> 5.0`). No module
+  resource required a configuration change: the module surface uses none of the
+  attributes removed in AWS provider 6.0, and `terraform validate` passes
+  against 6.x. Upgrade note: AWS provider 6.0 adds a per-resource `region`
+  attribute, so existing v0.1.x deployments should run
+  `terraform plan -refresh-only` followed by `terraform apply -refresh-only` to
+  settle state before applying further changes. Callers who must remain on AWS
+  provider 5.x should pin this module to `~> 0.1`.
+
 ## [0.1.0] - 2026-06-04
 
 Initial release on the Terraform Registry as `n8n-io/n8n/aws`.

--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ This contract goes away at 1.0.0 in favor of standard SemVer.
 
 ### Compatibility
 
-v0.1.0 ships against specific provider majors. Notably:
+This module ships against specific provider majors. Notably:
 
-- **AWS provider:** `~> 5.0`. Callers who already pin `aws ~> 6.0` in
-  their root module will hit a constraint conflict at `terraform init`.
-  A bump to `~> 6.0` is tracked for v0.2.0.
+- **AWS provider:** `~> 6.0`. Upgrading from a v0.1.x deployment (which
+  pinned `aws ~> 5.0`) requires a one-time `terraform plan -refresh-only`
+  followed by `terraform apply -refresh-only` to settle AWS provider 6.0's
+  per-resource `region` attribute into state before applying other changes.
+  Callers who must stay on AWS provider 5.x should pin this module to `~> 0.1`.
 - **Helm provider:** `~> 2.12`. A bump to `~> 3.0` is tracked for v0.2.0.
 - **Kubernetes provider:** `~> 2.0`.
 - **Terraform CLI:** `>= 1.9`.
@@ -294,7 +296,7 @@ keeps the last applied destinations but restores UI write access.
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
@@ -304,7 +306,7 @@ keeps the last applied destinations but restores UI write access.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.12 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |

--- a/README.md
+++ b/README.md
@@ -91,10 +91,8 @@ This module ships against specific provider majors. Notably:
   this module to `~> 0.1`.
 - **Kubernetes provider:** `~> 2.0`.
 - **Terraform CLI:** `>= 1.9`.
-- **n8n Helm chart:** validated against `1.4.0` (the current default).
-  Newer chart versions can be selected via `n8n_chart_version` but are
-  not part of the v0.1.0 test matrix; a default bump is tracked for
-  v0.2.0.
+- **n8n Helm chart:** default `1.10.0`. Other chart versions can be
+  selected via `n8n_chart_version`.
 - **EKS:** validated on Kubernetes `1.35`.
 - **PostgreSQL:** validated on RDS `16.9`.
 
@@ -398,7 +396,7 @@ No modules.
 | <a name="input_db_postgresdb_ssl_enabled"></a> [db\_postgresdb\_ssl\_enabled](#input\_db\_postgresdb\_ssl\_enabled) | Whether n8n connects to the database over SSL. Set to true (the default) for direct connections to RDS or Aurora — they use the AWS CA which Node.js doesn't trust by default, so the connection still negotiates SSL but skips certificate verification. Set to false when n8n connects to an in-cluster connection pooler (e.g. PgBouncer) that handles SSL on its upstream leg — the pod-to-pod traffic stays inside the cluster network. | `bool` | `true` | no |
 | <a name="input_db_storage_encrypted"></a> [db\_storage\_encrypted](#input\_db\_storage\_encrypted) | When true (the default), encrypt the RDS instance's storage, Performance Insights data, and the postgresql CloudWatch log group with a module-created Customer Managed KMS Key (aws\_kms\_key.db). Clears Checkov findings CKV\_AWS\_16, CKV\_AWS\_354, and CKV\_AWS\_158. Flipping this from false to true on an existing RDS instance forces a replacement — AWS does not support enabling storage encryption in place, so the upgrade path is snapshot → restore into a new encrypted instance. Set to false in your tfvars to preserve current behavior on pre-existing unencrypted deployments. The CMK rotates annually and uses a 7-day deletion window (AWS minimum). Ignored when create\_database = false. | `bool` | `true` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for the EKS cluster | `string` | `"1.35"` | no |
-| <a name="input_n8n_chart_version"></a> [n8n\_chart\_version](#input\_n8n\_chart\_version) | n8n Helm chart version to deploy | `string` | `"1.4.0"` | no |
+| <a name="input_n8n_chart_version"></a> [n8n\_chart\_version](#input\_n8n\_chart\_version) | n8n Helm chart version to deploy | `string` | `"1.10.0"` | no |
 | <a name="input_n8n_community_packages_prevent_loading"></a> [n8n\_community\_packages\_prevent\_loading](#input\_n8n\_community\_packages\_prevent\_loading) | Prevent installed community packages from being loaded at runtime. Maps to N8N\_COMMUNITY\_PACKAGES\_PREVENT\_LOADING. When true, n8n leaves the community-packages management surface in place but skips loading the package code, which is useful for locking an instance down without uninstalling. Leave false (the default) for community nodes to load and execute. n8n defaults this to false; when false the env var is omitted entirely so n8n's own default applies. | `bool` | `false` | no |
 | <a name="input_n8n_domain"></a> [n8n\_domain](#input\_n8n\_domain) | Fully-qualified domain name for n8n (e.g. n8n.example.com). Must match the CN / SAN on the certificate provided via certificate\_arn. | `string` | n/a | yes |
 | <a name="input_n8n_execution_concurrency_limit"></a> [n8n\_execution\_concurrency\_limit](#input\_n8n\_execution\_concurrency\_limit) | Maximum concurrent production executions (-1 to disable) | `number` | `100` | no |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ This module ships against specific provider majors. Notably:
   followed by `terraform apply -refresh-only` to settle AWS provider 6.0's
   per-resource `region` attribute into state before applying other changes.
   Callers who must stay on AWS provider 5.x should pin this module to `~> 0.1`.
-- **Helm provider:** `~> 2.12`. A bump to `~> 3.0` is tracked for v0.2.0.
+- **Helm provider:** `~> 3.0`. The 3.x release is a Plugin Framework
+  rewrite; `helm_release` drift detection is stricter, so the first
+  `terraform plan` after upgrading from v0.1.x may show in-place diffs on
+  existing releases. Callers who must stay on Helm provider 2.x should pin
+  this module to `~> 0.1`.
 - **Kubernetes provider:** `~> 2.0`.
 - **Terraform CLI:** `>= 1.9`.
 - **n8n Helm chart:** validated against `1.4.0` (the current default).
@@ -297,7 +301,7 @@ keeps the last applied destinations but restores UI write access.
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.12 |
@@ -307,7 +311,7 @@ keeps the last applied destinations but restores UI write access.
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.12 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 3.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.12 |

--- a/controllers.tf
+++ b/controllers.tf
@@ -19,23 +19,23 @@ resource "helm_release" "lbc" {
   atomic          = true
   cleanup_on_fail = true
 
-  set {
-    name  = "clusterName"
-    value = aws_eks_cluster.n8n.name
-  }
-
-  set {
-    name  = "vpcId"
-    value = local.vpc_id
-  }
-
-  # Prevent the LBC validating webhook from blocking Ingress deletions when
-  # LBC pods are unhealthy during destroy. With failurePolicy=Ignore, the
-  # webhook is best-effort — if LBC can't respond, the API server proceeds.
-  set {
-    name  = "webhookConfig.failurePolicy"
-    value = "Ignore"
-  }
+  set = [
+    {
+      name  = "clusterName"
+      value = aws_eks_cluster.n8n.name
+    },
+    {
+      name  = "vpcId"
+      value = local.vpc_id
+    },
+    # Prevent the LBC validating webhook from blocking Ingress deletions when
+    # LBC pods are unhealthy during destroy. With failurePolicy=Ignore, the
+    # webhook is best-effort — if LBC can't respond, the API server proceeds.
+    {
+      name  = "webhookConfig.failurePolicy"
+      value = "Ignore"
+    },
+  ]
 
   depends_on = [
     aws_eks_node_group.n8n,
@@ -61,20 +61,20 @@ resource "helm_release" "cluster_autoscaler" {
   atomic          = true
   cleanup_on_fail = true
 
-  set {
-    name  = "autoDiscovery.clusterName"
-    value = aws_eks_cluster.n8n.name
-  }
-
-  set {
-    name  = "awsRegion"
-    value = local.aws_region
-  }
-
-  set {
-    name  = "rbac.serviceAccount.name"
-    value = "cluster-autoscaler"
-  }
+  set = [
+    {
+      name  = "autoDiscovery.clusterName"
+      value = aws_eks_cluster.n8n.name
+    },
+    {
+      name  = "awsRegion"
+      value = local.aws_region
+    },
+    {
+      name  = "rbac.serviceAccount.name"
+      value = "cluster-autoscaler"
+    },
+  ]
 
   depends_on = [
     aws_eks_node_group.n8n,
@@ -105,15 +105,16 @@ resource "helm_release" "metrics_server" {
   atomic          = true
   cleanup_on_fail = true
 
-  set {
-    name  = "args[0]"
-    value = "--kubelet-insecure-tls"
-  }
-
-  set {
-    name  = "args[1]"
-    value = "--kubelet-preferred-address-types=InternalIP"
-  }
+  set = [
+    {
+      name  = "args[0]"
+      value = "--kubelet-insecure-tls"
+    },
+    {
+      name  = "args[1]"
+      value = "--kubelet-preferred-address-types=InternalIP"
+    },
+  ]
 
   depends_on = [aws_eks_node_group.n8n]
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,9 +16,9 @@ open /Users/<you>/Library/Caches/helm/repository/<repo>-index.yaml: no such file
 
 **Cause**
 
-The `hashicorp/helm` Terraform provider (v2.x) embeds Helm SDK v3 and reuses the local Helm CLI's repository cache (`$HELM_REPOSITORY_CACHE`). When the system Helm CLI is **Helm 4** (released 2025), the cache layout differs slightly from the v3 SDK's expectations and the SDK fails to find the index files even though the chart URL is hard-coded in the `helm_release` block.
+The `hashicorp/helm` Terraform provider embeds the Helm SDK v3 and reuses the local Helm CLI's repository cache (`$HELM_REPOSITORY_CACHE`). This is still true on the `~> 3.0` provider line this module pins: provider 3.x is a Plugin Framework rewrite, but it continues to vendor `helm.sh/helm/v3` (v3.18.5 as of provider v3.2.0), so the embedded SDK is unchanged from the 2.x era. When the system Helm CLI is **Helm 4** (released 2025), the cache layout differs slightly from the v3 SDK's expectations and the SDK fails to find the index files even though the chart URL is hard-coded in the `helm_release` block.
 
-This is environmental, not a module bug — but anyone running Helm 4 on macOS will see it.
+This is environmental, not a module bug — but anyone running Helm 4 on macOS will see it. The workaround below is unchanged under provider 3.x. (Note: if the repository cache is already populated — for example from earlier `helm repo add`/`helm repo update` runs — the apply succeeds without intervention; the failure only appears against an empty or Helm-4-only cache.)
 
 **Fix**
 

--- a/examples/cloudflare/README.md
+++ b/examples/cloudflare/README.md
@@ -61,7 +61,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 4.0.0, < 4.52.7 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
 ## Providers

--- a/examples/cloudflare/README.md
+++ b/examples/cloudflare/README.md
@@ -59,7 +59,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 4.0.0, < 4.52.7 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
@@ -68,7 +68,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 | <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 4.0.0, < 4.52.7 |
 
 ## Modules

--- a/examples/cloudflare/providers.tf
+++ b/examples/cloudflare/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/cloudflare/providers.tf
+++ b/examples/cloudflare/providers.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.12"
+      version = "~> 3.0"
     }
     cloudflare = {
       source = "cloudflare/cloudflare"
@@ -53,11 +53,11 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.n8n.cluster_endpoint
     cluster_ca_certificate = base64decode(module.n8n.cluster_certificate_authority_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", module.n8n.cluster_name, "--region", var.aws_region]

--- a/examples/godaddy/README.md
+++ b/examples/godaddy/README.md
@@ -56,7 +56,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_godaddy-dns"></a> [godaddy-dns](#requirement\_godaddy-dns) | ~> 0.3 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
@@ -65,7 +65,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 | <a name="provider_godaddy-dns"></a> [godaddy-dns](#provider\_godaddy-dns) | ~> 0.3 |
 
 ## Modules

--- a/examples/godaddy/README.md
+++ b/examples/godaddy/README.md
@@ -58,7 +58,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_godaddy-dns"></a> [godaddy-dns](#requirement\_godaddy-dns) | ~> 0.3 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
 ## Providers

--- a/examples/godaddy/providers.tf
+++ b/examples/godaddy/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/godaddy/providers.tf
+++ b/examples/godaddy/providers.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.12"
+      version = "~> 3.0"
     }
     godaddy-dns = {
       source = "veksh/godaddy-dns"
@@ -52,11 +52,11 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.n8n.cluster_endpoint
     cluster_ca_certificate = base64decode(module.n8n.cluster_certificate_authority_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", module.n8n.cluster_name, "--region", var.aws_region]

--- a/examples/large/README.md
+++ b/examples/large/README.md
@@ -128,7 +128,7 @@ The S3 `force_destroy` setting lives in the module and is not currently exposed 
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
@@ -137,7 +137,7 @@ The S3 `force_destroy` setting lives in the module and is not currently exposed 
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 

--- a/examples/large/README.md
+++ b/examples/large/README.md
@@ -129,7 +129,7 @@ The S3 `force_destroy` setting lives in the module and is not currently exposed 
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/examples/large/providers.tf
+++ b/examples/large/providers.tf
@@ -14,11 +14,11 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.n8n.cluster_endpoint
     cluster_ca_certificate = base64decode(module.n8n.cluster_certificate_authority_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", module.n8n.cluster_name, "--region", var.aws_region]

--- a/examples/large/versions.tf
+++ b/examples/large/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/large/versions.tf
+++ b/examples/large/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.12"
+      version = "~> 3.0"
     }
     # random is declared at the example level (not just inherited from the
     # module) because aurora.tf uses random_password.aurora directly to

--- a/examples/medium/README.md
+++ b/examples/medium/README.md
@@ -86,7 +86,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
@@ -94,7 +94,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 

--- a/examples/medium/README.md
+++ b/examples/medium/README.md
@@ -87,7 +87,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
 ## Providers

--- a/examples/medium/providers.tf
+++ b/examples/medium/providers.tf
@@ -14,11 +14,11 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.n8n.cluster_endpoint
     cluster_ca_certificate = base64decode(module.n8n.cluster_certificate_authority_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", module.n8n.cluster_name, "--region", var.aws_region]

--- a/examples/medium/versions.tf
+++ b/examples/medium/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/medium/versions.tf
+++ b/examples/medium/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.12"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/small/README.md
+++ b/examples/small/README.md
@@ -53,7 +53,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
@@ -61,7 +61,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 

--- a/examples/small/README.md
+++ b/examples/small/README.md
@@ -54,7 +54,7 @@ These settings live in the module's `database.tf` and `s3.tf` and are not curren
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
 ## Providers

--- a/examples/small/providers.tf
+++ b/examples/small/providers.tf
@@ -19,11 +19,11 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.n8n.cluster_endpoint
     cluster_ca_certificate = base64decode(module.n8n.cluster_certificate_authority_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", module.n8n.cluster_name, "--region", var.aws_region]

--- a/examples/small/versions.tf
+++ b/examples/small/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/small/versions.tf
+++ b/examples/small/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.12"
+      version = "~> 3.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -179,7 +179,7 @@ variable "node_max" {
 variable "n8n_chart_version" {
   description = "n8n Helm chart version to deploy"
   type        = string
-  default     = "1.4.0"
+  default     = "1.10.0"
 }
 
 variable "n8n_helm_timeout" {

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.12"
+      version = "~> 3.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Summary

Bumps the two major provider constraints and the default n8n chart version. Targets a v0.2.0 release.

- **AWS provider `~> 5.0` -> `~> 6.0`** (module root + all examples). No module resource needed a config change; the surface uses none of the attributes removed in 6.0 and `terraform validate` passes.
- **Helm provider `~> 2.12` -> `~> 3.0`** (Plugin Framework rewrite). Converted the controller `set` blocks (`controllers.tf`) to the `set = [...]` list form, and the example `provider "helm"` blocks to the `kubernetes = { ... }` / `exec = { ... }` object form.
- **Default `n8n_chart_version` `1.4.0` -> `1.10.0`** (official `oci://ghcr.io/n8n-io/n8n-helm-chart`).

## Validation

Verified the full upgrade lifecycle against live AWS (`examples/small`), not just plan-time:

1. Fresh `terraform apply` on `0.1.0` (Helm v2.17.0, AWS v5.100.0) -> `71 added`, n8n chart 1.4.0, all pods healthy.
2. `git checkout` this branch + `terraform init -upgrade` -> migrated to Helm v3.2.0 / AWS v6.52.0 against the existing state.
3. `terraform plan` -> **0 add, 5 change, 0 destroy** (the 5 `helm_release` resources updated in-place; no replacements, no AWS-6 drift). The `UpgradeState Triggered` notices are the expected Helm SDKv2 -> Plugin Framework state migration.
4. `terraform apply` -> **0 added, 5 changed, 0 destroyed**. All releases revision 1 -> 2, n8n chart 1.4.0 -> 1.10.0, pods rolled cleanly (app 2.27.4), ALB hostname unchanged.
5. Post-deploy smoke test (`tests/scripts/smoke-test.sh`, `LOAD_TEST=true`): **22 passed, 0 failed, 0 warnings**, including end-to-end queue execution and KEDA worker scale-up (1 -> 4).
6. `terraform destroy` -> `71 destroyed`, clean teardown.

## Upgrade notes for consumers

- AWS provider 6.0 adds a per-resource `region` attribute; existing v0.1.x deployments should run a `-refresh-only` plan/apply to settle state first.
- Helm provider 3.x drift detection is stricter; the first plan after upgrading may show in-place diffs on existing `helm_release` resources.
- Applying the new default `n8n_chart_version` cycles the n8n pods; pin `n8n_chart_version` to stay on a specific chart release.
- Callers who must stay on AWS 5.x / Helm 2.x should pin this module to `~> 0.1`.

## Resolves

- Closes #25 (bump AWS provider to `~> 6.0`)
- Closes #26 (bump Helm provider to `~> 3.0`)
- Closes #24 (bump n8n Helm chart default to a current version)

## Related

- Surfaced #38 (floating `stable` image tag -> expose `n8n_image_tag`) during validation; tracked separately, out of scope here.
