### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to the stability contract in
 [README.md → Stability & versioning](./README.md#stability--versioning).
 
-## [Unreleased]
+## [0.2.0] - 2026-07-15
+
+Minor release per the [stability contract](./README.md#stability--versioning):
+the AWS and Helm provider floor bumps below are breaking for callers pinned
+to the previous majors. Pin this module to `~> 0.1` to stay on the old
+providers, or retype your constraint to `~> 0.2` and read the upgrade notes
+under **Changed**.
 
 ### Added
 
@@ -96,6 +102,27 @@ this project adheres to the stability contract in
   specific chart release. Validated by a real apply of examples/small plus the
   post-deploy smoke test.
 
+### Compatibility
+
+- **AWS provider:** `~> 6.0` (see upgrade note under **Changed**).
+- **Helm provider:** `~> 3.0` (see upgrade note under **Changed**).
+- **Kubernetes provider:** `~> 2.0`.
+- **Terraform CLI:** `>= 1.9`.
+- **n8n Helm chart:** validated against `1.10.0` (the current default) via a
+  real apply of `examples/small` plus the post-deploy smoke test. Newer chart
+  versions can be selected via `n8n_chart_version` but are not part of the
+  v0.2.0 test matrix.
+- **Kubernetes:** validated on EKS 1.35.
+- **PostgreSQL:** validated on RDS `16.9`.
+
+### Known limitations
+
+- Checkov still runs in `soft_fail` mode; findings are surfaced but do not
+  block CI. The curated suppressions and flip to hard-fail announced in
+  v0.1.0 are deferred to a later release.
+- See [README.md → Out of scope](./README.md#out-of-scope) for what this
+  release explicitly does not cover.
+
 ## [0.1.0] - 2026-06-04
 
 Initial release on the Terraform Registry as `n8n-io/n8n/aws`.
@@ -158,5 +185,6 @@ Initial release on the Terraform Registry as `n8n-io/n8n/aws`.
   block CI. Curated suppressions and a flip to hard-fail are tracked
   for v0.2.0.
 
-[Unreleased]: https://github.com/n8n-io/terraform-aws-n8n/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/n8n-io/terraform-aws-n8n/releases/tag/v0.1.0
+[Unreleased]: https://github.com/n8n-io/terraform-aws-n8n/compare/0.2.0...HEAD
+[0.2.0]: https://github.com/n8n-io/terraform-aws-n8n/compare/0.1.0...0.2.0
+[0.1.0]: https://github.com/n8n-io/terraform-aws-n8n/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ this project adheres to the stability contract in
 
 Minor release per the [stability contract](./README.md#stability--versioning):
 the AWS and Helm provider floor bumps below are breaking for callers pinned
-to the previous majors. Pin this module to `~> 0.1` to stay on the old
-providers, or retype your constraint to `~> 0.2` and read the upgrade notes
+to the previous majors. Pin this module to `~> 0.1.0` to stay on the old
+providers, or retype your constraint to `~> 0.2.0` and read the upgrade notes
 under **Changed**.
 
 ### Added
@@ -87,7 +87,7 @@ under **Changed**.
   attribute, so existing v0.1.x deployments should run
   `terraform plan -refresh-only` followed by `terraform apply -refresh-only` to
   settle state before applying further changes. Callers who must remain on AWS
-  provider 5.x should pin this module to `~> 0.1`.
+  provider 5.x should pin this module to `~> 0.1.0`.
 - **Helm provider requirement bumped to `~> 3.0`** (was `~> 2.12`). Helm
   provider 3.0 is a Plugin Framework rewrite. The `set` blocks on the bundled
   controller releases (AWS Load Balancer Controller, Cluster Autoscaler,
@@ -96,7 +96,7 @@ under **Changed**.
   form. Upgrade note: drift detection is stricter in 3.x, so the first
   `terraform plan` after upgrading may show in-place diffs on existing
   `helm_release` resources. Callers who must remain on Helm provider 2.x should
-  pin this module to `~> 0.1`.
+  pin this module to `~> 0.1.0`.
 - **Default `n8n_chart_version` bumped to `1.10.0`** (was `1.4.0`). Applying
   this default change cycles the n8n pods. Pin `n8n_chart_version` to stay on a
   specific chart release. Validated by a real apply of examples/small plus the

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ PersistentVolumeClaims from workloads deployed beside n8n bind out of the box
 ```hcl
 module "n8n" {
   source  = "n8n-io/n8n/aws"
-  version = "~> 0.1"
+  version = "~> 0.2.0"
 
   aws_region      = "us-east-1"
   cluster_name    = "n8n-cluster"
@@ -77,10 +77,12 @@ bug-fix changes.
 | `0.MINOR.PATCH` → `0.MINOR.PATCH+1` | Bug fixes, new optional inputs, new outputs, new resources whose absence wouldn't affect existing callers. No removed or renamed inputs/outputs. No changed defaults that move infra. No changed resource addresses. |
 | `0.MINOR` → `0.MINOR+1` | Anything else, including removed inputs, renamed inputs, default changes that force resource replacement, refactored resource addresses, and bumped provider version floors. Each such change is called out in [`CHANGELOG.md`](./CHANGELOG.md) with an upgrade note. |
 
-Pin with `version = "~> 0.1"` to auto-receive 0.1.x patches without
-accidentally crossing a 0.1 → 0.2 boundary. To upgrade across minor
-lines, retype the constraint (`version = "~> 0.2"`) and read the
-release notes.
+Pin with `version = "~> 0.2.0"` to auto-receive 0.2.x patches without
+accidentally crossing a 0.2 → 0.3 boundary. Note the three-component
+constraint: `~> 0.2.0` resolves to `>= 0.2.0, < 0.3.0`, whereas the
+two-component `~> 0.2` would resolve to `>= 0.2, < 1.0` and let you cross
+minor boundaries unintentionally. To upgrade across minor lines, retype
+the constraint (e.g. `version = "~> 0.3.0"`) and read the release notes.
 
 This contract goes away at 1.0.0 in favor of standard SemVer.
 
@@ -92,12 +94,12 @@ This module ships against specific provider majors. Notably:
   pinned `aws ~> 5.0`) requires a one-time `terraform plan -refresh-only`
   followed by `terraform apply -refresh-only` to settle AWS provider 6.0's
   per-resource `region` attribute into state before applying other changes.
-  Callers who must stay on AWS provider 5.x should pin this module to `~> 0.1`.
+  Callers who must stay on AWS provider 5.x should pin this module to `~> 0.1.0`.
 - **Helm provider:** `~> 3.0`. The 3.x release is a Plugin Framework
   rewrite; `helm_release` drift detection is stricter, so the first
   `terraform plan` after upgrading from v0.1.x may show in-place diffs on
   existing releases. Callers who must stay on Helm provider 2.x should pin
-  this module to `~> 0.1`.
+  this module to `~> 0.1.0`.
 - **Kubernetes provider:** `~> 2.0`.
 - **Terraform CLI:** `>= 1.9`.
 - **n8n Helm chart:** default `1.10.0`. Other chart versions can be

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This module ships against specific provider majors. Notably:
 
 ## Out of scope
 
-v0.1.0 intentionally does not cover the following. Each item is
+v0.2.0 intentionally does not cover the following. Each item is
 documented here so that issues filed against them can be triaged
 quickly; several are candidates for future minor releases (see
 [`ROADMAP.md`](./ROADMAP.md)).


### PR DESCRIPTION
# 0.2.0 release

This PR cuts release 0.2.0 of `terraform-aws-n8n`, following the process
established in #21 (release PR → merge commit → annotated tag on `main`).
Per the stability contract this is a **minor** release: the AWS (`~> 6.0`)
and Helm (`~> 3.0`) provider floor bumps are breaking for callers pinned
to the previous majors.

## Scope

Everything merged to `main` since the `0.1.0` tag (21 commits), notably:

- **Breaking:** AWS provider `~> 6.0` (was `~> 5.0`), Helm provider `~> 3.0` (was `~> 2.12`) — #39
- Default n8n chart version bumped to `1.10.0` (was `1.4.0`) — #39
- EBS CSI driver addon + default encrypted gp3 StorageClass — #45
- `n8n_image_tag` input to pin the n8n application image — #46
- `n8n_extra_env` escape hatch with contract validation — #31
- OpenTelemetry tracing toggles — #28
- Enterprise log streaming managed via env vars — #37
- `n8n_templates_enabled` / `n8n_personalization_enabled` toggles — #36
- Community package toggles (`n8n_reinstall_missing_packages`, `n8n_community_packages_prevent_loading`) — #33

## Changes in this PR

- `CHANGELOG.md`: Unreleased → `[0.2.0] - 2026-07-15`, plus Compatibility
  and Known limitations sections (Checkov hard-fail flip announced in
  v0.1.0 is deferred to a later release).
- Tag links standardized on the unprefixed convention (`0.1.0`, `0.2.0`),
  matching the actual `0.1.0` tag on GitHub. The previous `v0.1.0` links
  were broken.
- `README.md`: Out of scope section bumped to v0.2.0.

## Pre-release verification (all green)

- `terraform fmt -check -recursive`
- `terraform validate` — module root + all 5 examples
- `terraform test` — root suite (55 passed) + all 5 example suites
- `tflint` — module root
- `terraform-docs --output-check .` — root + all 5 examples
- CI green on `main`

## Live AWS validation (completed)

Ran against a real account (`us-east-1`, `examples/small`):

- **0.1.0 baseline:** fresh `terraform apply` (79 resources), all pods Running, HTTPS/ACM healthy, smoke test **23/23 pass**.
- **0.1.0 → 0.2.0 in-place upgrade:** provider bump (aws 5.x → 6.54.0, helm 2.x → 3.2.0), refresh-only settle, then `apply` = **4 added, 6 changed, 0 destroyed** (n8n chart 1.4.0 → 1.10.0, EBS CSI addon + default gp3 StorageClass). Pods rolled cleanly; smoke test **26/26 pass**.
- **Teardown:** `terraform destroy` = **75 destroyed**, no orphans.
- The compatibility section's refresh-only upgrade note is verified accurate.

Also addressed the cubic review: switched patch-line version pins to the three-component form (`~> 0.1.0` / `~> 0.2.0`) across the README and CHANGELOG (P1), and the validation claim above resolves P2.

## Release-day checklist (after testing on this PR)

- [x] Manual testing on this PR complete
- [ ] Merge with a **merge commit** (not squash/rebase, per the #21 convention)
- [ ] Annotated tag `0.2.0` on the merge commit on `main` (no `v` prefix — standardized on the existing `0.1.0` convention)
- [ ] Create the GitHub release from the tag (decide whether to keep the Pre-release flag; `0.1.0` was marked Pre-release)
- [ ] Confirm the Terraform Registry picks up `0.2.0` for `n8n-io/n8n/aws`
- [ ] Delete the `release/0.2.0` branch

