### PR TITLE
chore: vendor HashiCorp Terraform agent skills

### DIFF
--- a/.agents/skills/terraform-style-guide/SECURITY.md
+++ b/.agents/skills/terraform-style-guide/SECURITY.md
@@ -1,0 +1,164 @@
+---
+name: terraform-style-guide-security
+description: Generate Terraform HCL code following HashiCorp's security practices
+---
+
+# Terraform Style Guide - Security
+
+When generating code, apply security hardening:
+
+- Enable encryption at rest by default
+- Configure private networking where applicable
+- Apply principle of least privilege for security groups
+- Enable logging and monitoring
+- Never hardcode credentials or secrets
+- Mark sensitive outputs with `sensitive = true`
+- Use `ephemeral` resources and write-only attributes
+  for sensitive data when possible
+
+## Example: Secure S3 Bucket
+
+```hcl
+resource "aws_s3_bucket" "data" {
+  bucket = "${var.project}-${var.environment}-data"
+  tags   = local.common_tags
+}
+
+resource "aws_s3_bucket_versioning" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+## Ephemeral resources
+
+Ephemeral resources prevent sensitive data being stored in state.
+For more information on ephemeral resources, see the
+[Terraform documentation](https://developer.hashicorp.com/terraform/language/block/ephemeral).
+
+Before you generate code for an ephemeral resource, check that the Terraform
+version is greater than or equal to 1.11.0.
+
+Then, follow this priority order for managing sensitive attributes:
+
+1. **First priority: Native secrets manager integration**
+   If a resource has the ability to automatically manage a sensitive attribute by
+   storing it in a secrets manager (e.g., AWS Secrets Manager, Azure Key Vault),
+   use that configuration. This is the preferred approach.
+
+   ```hcl
+   # Bad
+   resource "aws_rds_cluster" "example" {
+     cluster_identifier = "example"
+     database_name      = "test"
+     master_username    = "test"
+     master_password    = var.db_master_password
+   }
+
+   # Good, managed by AWS Secrets Manager by default
+   resource "aws_rds_cluster" "test" {
+     cluster_identifier          = "example"
+     database_name               = "test"
+     manage_master_user_password = true
+     master_username             = "test"
+   }
+   ```
+
+2. **Second priority: Write-only attributes with ephemeral resources**
+   If a resource has a write-only attribute but no native secrets manager integration,
+   use an `ephemeral` resource for the sensitive data and pass that to the write-only
+   attribute. Default the write-only version to 1.
+
+   ```hcl
+   # Bad
+   resource "random_password" "password" {
+     length           = 16
+     special          = true
+     override_special = "!#$%&*()-_=+[]{}<>:?"
+   }
+
+   resource "vault_kv_secret_v2" "example" {
+     mount               = vault_mount.kvv2.path
+     name                = "secret"
+
+     data_json = jsonencode(
+       {
+         password = "${random_password.password.result}",
+       }
+     )
+   }
+
+   # Good
+   ephemeral "random_password" "password" {
+     length           = 16
+     special          = true
+     override_special = "!#$%&*()-_=+[]{}<>:?"
+   }
+
+   resource "vault_kv_secret_v2" "example" {
+     mount               = vault_mount.kvv2.path
+     name                = "secret"
+
+     data_json_wo = jsonencode(
+       {
+         password = "${ephemeral.random_password.password.result}",
+       }
+     )
+     data_json_wo_version = 1
+   }
+   ```
+
+   If you need to retrieve a secret from a secrets manager to pass
+   to a resource, use the `ephemeral` version of the resource to
+   retrieve the secret and pass it to another resource.
+
+   ```hcl
+   # Good
+   ephemeral "vault_kv_secret_v2" "db_secret" {
+     mount = vault_mount.kvv2.path
+     mount_id = vault_mount.kvv2.id
+     name = vault_kv_secret_v2.db_root.name
+   }
+
+   resource "vault_database_secret_backend_connection" "postgres" {
+     backend       = vault_mount.db.path
+     name          = "postrgres-db"
+     allowed_roles = ["*"]
+
+     postgresql {
+       connection_url = "postgresql://{{username}}:{{password}}@localhost:5432/postgres"
+       password_authentication = ""
+       username = "postgres"
+       password_wo = tostring(ephemeral.vault_kv_secret_v2.db_secret.data.password)
+       password_wo_version = 1
+     }
+   }
+   ```
+
+3. **Last resort: Regular resources**
+   Only use a regular resource that has sensitive data written to state if neither of the above
+   options are available, resource does not offer a write-only attribute or ephemeral resource
+   alternative, or the Terraform version is less than 1.11.0.

--- a/.agents/skills/terraform-style-guide/SKILL.md
+++ b/.agents/skills/terraform-style-guide/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: terraform-style-guide
+description: Generate Terraform HCL code following HashiCorp's official style conventions and best practices. Use when writing, reviewing, or generating Terraform configurations.
+---
+
+# Terraform Style Guide
+
+Generate and maintain Terraform code following HashiCorp's official style conventions and best practices.
+
+**Reference:** [HashiCorp Terraform Style Guide](https://developer.hashicorp.com/terraform/language/style)
+
+## Code Generation Strategy
+
+When generating Terraform code:
+
+1. Start with provider configuration and version constraints
+2. Create data sources before dependent resources
+3. Build resources in dependency order
+4. Add outputs for key resource attributes
+5. Use variables for all configurable values
+
+## File Organization
+
+| File | Purpose |
+|------|---------|
+| `terraform.tf` | Terraform and provider version requirements |
+| `providers.tf` | Provider configurations |
+| `main.tf` | Primary resources and data sources |
+| `variables.tf` | Input variable declarations (alphabetical) |
+| `outputs.tf` | Output value declarations (alphabetical) |
+| `locals.tf` | Local value declarations |
+
+### Example Structure
+
+```hcl
+# terraform.tf
+terraform {
+  required_version = ">= 1.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# variables.tf
+variable "environment" {
+  description = "Target deployment environment"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod."
+  }
+}
+
+# locals.tf
+locals {
+  common_tags = {
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+  }
+}
+
+# main.tf
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-vpc"
+  })
+}
+
+# outputs.tf
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.main.id
+}
+```
+
+## Code Formatting
+
+### Indentation and Alignment
+
+- Use **two spaces** per nesting level (no tabs)
+- Align equals signs for consecutive arguments
+
+```hcl
+resource "aws_instance" "web" {
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "t2.micro"
+  subnet_id     = "subnet-12345678"
+
+  tags = {
+    Name        = "web-server"
+    Environment = "production"
+  }
+}
+```
+
+### Block Organization
+
+Arguments precede blocks, with meta-arguments first:
+
+```hcl
+resource "aws_instance" "example" {
+  # Meta-arguments
+  count = 3
+
+  # Arguments
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "t2.micro"
+
+  # Blocks
+  root_block_device {
+    volume_size = 20
+  }
+
+  # Lifecycle last
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+## Naming Conventions
+
+- Use **lowercase with underscores** for all names
+- Use **descriptive nouns** excluding the resource type
+- Be specific and meaningful
+- Resource names must be singular, not plural
+- Default to `main` for resources where a specific descriptive name is redundant or unavailable, provided only one instance exists
+
+```hcl
+# Bad
+resource "aws_instance" "webAPI-aws-instance" {}
+resource "aws_instance" "web_apis" {}
+variable "name" {}
+
+# Good
+resource "aws_instance" "web_api" {}
+resource "aws_vpc" "main" {}
+variable "application_name" {}
+```
+
+## Variables
+
+Every variable must include `type` and `description`:
+
+```hcl
+variable "instance_type" {
+  description = "EC2 instance type for the web server"
+  type        = string
+  default     = "t2.micro"
+
+  validation {
+    condition     = contains(["t2.micro", "t2.small", "t2.medium"], var.instance_type)
+    error_message = "Instance type must be t2.micro, t2.small, or t2.medium."
+  }
+}
+
+variable "database_password" {
+  description = "Password for the database admin user"
+  type        = string
+  sensitive   = true
+}
+```
+
+## Outputs
+
+Every output must include `description`:
+
+```hcl
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.web.id
+}
+
+output "database_password" {
+  description = "Database administrator password"
+  value       = aws_db_instance.main.password
+  sensitive   = true
+}
+```
+
+## Dynamic Resource Creation
+
+### Prefer for_each over count
+
+```hcl
+# Bad - count for multiple resources
+resource "aws_instance" "web" {
+  count = var.instance_count
+  tags  = { Name = "web-${count.index}" }
+}
+
+# Good - for_each with named instances
+variable "instance_names" {
+  type    = set(string)
+  default = ["web-1", "web-2", "web-3"]
+}
+
+resource "aws_instance" "web" {
+  for_each = var.instance_names
+  tags     = { Name = each.key }
+}
+```
+
+### count for Conditional Creation
+
+```hcl
+resource "aws_cloudwatch_metric_alarm" "cpu" {
+  count = var.enable_monitoring ? 1 : 0
+
+  alarm_name = "high-cpu-usage"
+  threshold  = 80
+}
+```
+
+## Security Best Practices
+
+Refer to SECURITY.md. It includes guidance on encrypting resources,
+preventing sensitive data in state, and secure configurations.
+
+## Version Pinning
+
+```hcl
+terraform {
+  required_version = ">= 1.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+```
+
+Use the latest major version of each provider and the latest minor version of
+Terraform, unless otherwise constrained by a dependency lock file or by other
+modules used by the configuration.
+
+**Version constraint operators:**
+- `= 1.0.0` - Exact version
+- `>= 1.0.0` - Greater than or equal
+- `~> 1.0` - Allow rightmost component to increment
+- `>= 1.0, < 2.0` - Version range
+
+## Provider Configuration
+
+```hcl
+provider "aws" {
+  region = "us-west-2"
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}
+
+# Aliased provider for multi-region
+provider "aws" {
+  alias  = "east"
+  region = "us-east-1"
+}
+```
+
+## Version Control
+
+**Never commit:**
+- `terraform.tfstate`, `terraform.tfstate.backup`
+- `.terraform/` directory
+- `*.tfplan`
+- `.tfvars` files with sensitive data
+
+**Always commit:**
+- All `.tf` configuration files
+- `.terraform.lock.hcl` (dependency lock file)
+
+## Validation Tools
+
+Run before committing:
+
+```bash
+terraform fmt -recursive
+terraform validate
+```
+
+Additional tools:
+- `tflint` - Linting and best practices
+- `checkov` / `tfsec` - Security scanning
+
+## Code Review Checklist
+
+- [ ] Code formatted with `terraform fmt`
+- [ ] Configuration validated with `terraform validate`
+- [ ] Files organized according to standard structure
+- [ ] All variables have type and description
+- [ ] All outputs have descriptions
+- [ ] Resource names use descriptive nouns with underscores
+- [ ] Version constraints pinned explicitly
+- [ ] Sensitive values marked with `sensitive = true`
+- [ ] No hardcoded credentials or secrets
+- [ ] Security best practices applied
+
+---
+
+*Based on: [HashiCorp Terraform Style Guide](https://developer.hashicorp.com/terraform/language/style)*

--- a/.agents/skills/terraform-test/SKILL.md
+++ b/.agents/skills/terraform-test/SKILL.md
@@ -1,0 +1,451 @@
+---
+name: terraform-test
+description: Comprehensive guide for writing and running Terraform tests. Use when creating test files (.tftest.hcl), writing test scenarios with run blocks, validating infrastructure behavior with assertions, mocking providers and data sources, testing module outputs and resource configurations, or troubleshooting Terraform test syntax and execution.
+metadata:
+  copyright: Copyright IBM Corp. 2026
+  version: "0.0.2"
+---
+
+# Terraform Test
+
+Terraform's built-in testing framework validates that configuration updates don't introduce breaking changes. Tests run against temporary resources, protecting existing infrastructure and state files.
+
+## Reference Files
+
+- `references/MOCK_PROVIDERS.md` — Mock provider syntax, common defaults, when to use mocks (Terraform 1.7.0+ only — skip if the user's version is below 1.7)
+- `references/CI_CD.md` — GitHub Actions and GitLab CI pipeline examples
+- `references/EXAMPLES.md` — Complete example test suite (unit, integration, and mock tests for a VPC module)
+
+Read the relevant reference file when the user asks about mocking, CI/CD integration, or wants a full example.
+
+## Core Concepts
+
+- **Test file** (`.tftest.hcl` / `.tftest.json`): Contains `run` blocks that validate your configuration
+- **Run block**: A single test scenario with optional variables, providers, and assertions
+- **Assert block**: Conditions that must be true for the test to pass
+- **Mock provider**: Simulates provider behavior without real infrastructure (Terraform 1.7.0+)
+- **Test modes**: `apply` (default, creates real resources) or `plan` (validates logic only)
+
+## File Structure
+
+```
+my-module/
+├── main.tf
+├── variables.tf
+├── outputs.tf
+└── tests/
+    ├── defaults_unit_test.tftest.hcl         # plan mode — fast, no resources
+    ├── validation_unit_test.tftest.hcl        # plan mode
+    └── full_stack_integration_test.tftest.hcl # apply mode — creates real resources
+```
+
+Use `*_unit_test.tftest.hcl` for plan-mode tests and `*_integration_test.tftest.hcl` for apply-mode tests so they can be filtered separately in CI.
+
+## Test File Structure
+
+```hcl
+# Optional: test-wide settings
+test {
+  parallel = true  # Enable parallel execution for all run blocks (default: false)
+}
+
+# Optional: file-level variables (highest precedence, override all other sources)
+variables {
+  aws_region    = "us-west-2"
+  instance_type = "t2.micro"
+}
+
+# Optional: provider configuration
+provider "aws" {
+  region = var.aws_region
+}
+
+# Required: at least one run block
+run "test_default_configuration" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.example.instance_type == "t2.micro"
+    error_message = "Instance type should be t2.micro by default"
+  }
+}
+```
+
+## Run Block
+
+```hcl
+run "test_name" {
+  command  = plan  # or apply (default)
+  parallel = true  # optional, since v1.9.0
+
+  # Override file-level variables
+  variables {
+    instance_type = "t3.large"
+  }
+
+  # Reference a specific module
+  module {
+    source  = "./modules/vpc"  # local or registry only (not git/http)
+    version = "5.0.0"          # registry modules only
+  }
+
+  # Control state isolation
+  state_key = "shared_state"  # since v1.9.0
+
+  # Plan behavior
+  plan_options {
+    mode    = refresh-only  # or normal (default)
+    refresh = true
+    replace = [aws_instance.example]
+    target  = [aws_instance.example]
+  }
+
+  # Assertions
+  assert {
+    condition     = aws_instance.example.id != ""
+    error_message = "Instance should have a valid ID"
+  }
+
+  # Expected failures (test passes if these fail)
+  expect_failures = [
+    var.instance_count
+  ]
+}
+```
+
+## Common Test Patterns
+
+### Validate outputs
+
+```hcl
+run "test_outputs" {
+  command = plan
+
+  assert {
+    condition     = output.vpc_id != null
+    error_message = "VPC ID output must be defined"
+  }
+
+  assert {
+    condition     = can(regex("^vpc-", output.vpc_id))
+    error_message = "VPC ID should start with 'vpc-'"
+  }
+}
+```
+
+### Conditional resources
+
+```hcl
+run "test_nat_gateway_disabled" {
+  command = plan
+
+  variables {
+    create_nat_gateway = false
+  }
+
+  assert {
+    condition     = length(aws_nat_gateway.main) == 0
+    error_message = "NAT gateway should not be created when disabled"
+  }
+}
+```
+
+### Resource counts
+
+```hcl
+run "test_resource_count" {
+  command = plan
+
+  variables {
+    instance_count = 3
+  }
+
+  assert {
+    condition     = length(aws_instance.workers) == 3
+    error_message = "Should create exactly 3 worker instances"
+  }
+}
+```
+
+### Tags
+
+```hcl
+run "test_resource_tags" {
+  command = plan
+
+  variables {
+    common_tags = {
+      Environment = "production"
+      ManagedBy   = "Terraform"
+    }
+  }
+
+  assert {
+    condition     = aws_instance.example.tags["Environment"] == "production"
+    error_message = "Environment tag should be set correctly"
+  }
+
+  assert {
+    condition     = aws_instance.example.tags["ManagedBy"] == "Terraform"
+    error_message = "ManagedBy tag should be set correctly"
+  }
+}
+```
+
+### Data sources
+
+```hcl
+run "test_data_source_lookup" {
+  command = plan
+
+  assert {
+    condition     = data.aws_ami.ubuntu.id != ""
+    error_message = "Should find a valid Ubuntu AMI"
+  }
+
+  assert {
+    condition     = can(regex("^ami-", data.aws_ami.ubuntu.id))
+    error_message = "AMI ID should be in correct format"
+  }
+}
+```
+
+### Validation rules
+
+```hcl
+run "test_invalid_environment" {
+  command = plan
+
+  variables {
+    environment = "invalid"
+  }
+
+  expect_failures = [
+    var.environment
+  ]
+}
+```
+
+### Sequential tests with dependencies
+
+```hcl
+run "setup_vpc" {
+  command = apply
+
+  assert {
+    condition     = output.vpc_id != ""
+    error_message = "VPC should be created"
+  }
+}
+
+run "test_subnet_in_vpc" {
+  command = plan
+
+  variables {
+    vpc_id = run.setup_vpc.vpc_id
+  }
+
+  assert {
+    condition     = aws_subnet.example.vpc_id == run.setup_vpc.vpc_id
+    error_message = "Subnet should be in the VPC from setup_vpc"
+  }
+}
+```
+
+### Plan options (refresh-only, targeted)
+
+```hcl
+run "test_refresh_only" {
+  command = plan
+
+  plan_options {
+    mode = refresh-only
+  }
+
+  assert {
+    condition     = aws_instance.example.tags["Environment"] == "production"
+    error_message = "Tags should be refreshed correctly"
+  }
+}
+
+run "test_specific_resource" {
+  command = plan
+
+  plan_options {
+    target = [aws_instance.example]
+  }
+
+  assert {
+    condition     = aws_instance.example.instance_type == "t2.micro"
+    error_message = "Targeted resource should be planned"
+  }
+}
+```
+
+### Parallel modules
+
+```hcl
+run "test_networking_module" {
+  command  = plan
+  parallel = true
+
+  module {
+    source = "./modules/networking"
+  }
+
+  assert {
+    condition     = output.vpc_id != ""
+    error_message = "VPC should be created"
+  }
+}
+
+run "test_compute_module" {
+  command  = plan
+  parallel = true
+
+  module {
+    source = "./modules/compute"
+  }
+
+  assert {
+    condition     = output.instance_id != ""
+    error_message = "Instance should be created"
+  }
+}
+```
+
+### State key sharing
+
+```hcl
+run "create_foundation" {
+  command   = apply
+  state_key = "foundation"
+
+  assert {
+    condition     = aws_vpc.main.id != ""
+    error_message = "Foundation VPC should be created"
+  }
+}
+
+run "create_application" {
+  command   = apply
+  state_key = "foundation"
+
+  variables {
+    vpc_id = run.create_foundation.vpc_id
+  }
+
+  assert {
+    condition     = aws_instance.app.vpc_id == run.create_foundation.vpc_id
+    error_message = "Application should use foundation VPC"
+  }
+}
+```
+
+### Cleanup ordering (S3 objects before bucket)
+
+```hcl
+run "create_bucket" {
+  command = apply
+
+  assert {
+    condition     = aws_s3_bucket.example.id != ""
+    error_message = "Bucket should be created"
+  }
+}
+
+run "add_objects" {
+  command = apply
+
+  assert {
+    condition     = length(aws_s3_object.files) > 0
+    error_message = "Objects should be added"
+  }
+}
+
+# Cleanup destroys in reverse: objects first, then bucket
+```
+
+### Multiple aliased providers
+
+```hcl
+provider "aws" {
+  alias  = "primary"
+  region = "us-west-2"
+}
+
+provider "aws" {
+  alias  = "secondary"
+  region = "us-east-1"
+}
+
+run "test_with_specific_provider" {
+  command = plan
+
+  providers = {
+    aws = provider.aws.secondary
+  }
+
+  assert {
+    condition     = aws_instance.example.availability_zone == "us-east-1a"
+    error_message = "Instance should be in us-east-1 region"
+  }
+}
+```
+
+### Complex conditions
+
+```hcl
+assert {
+  condition = alltrue([
+    for subnet in aws_subnet.private :
+    can(regex("^10\\.0\\.", subnet.cidr_block))
+  ])
+  error_message = "All private subnets should use 10.0.0.0/8 CIDR range"
+}
+```
+
+## Cleanup
+
+Resources are destroyed in **reverse run block order** after test completion. This matters for dependencies (e.g., S3 objects before bucket). Use `terraform test -no-cleanup` to skip cleanup for debugging.
+
+## Running Tests
+
+```bash
+terraform test                                        # all tests
+terraform test tests/defaults.tftest.hcl             # specific file
+terraform test -filter=test_vpc_configuration        # by run block name
+terraform test -test-directory=integration-tests     # custom directory
+terraform test -verbose                              # detailed output
+terraform test -no-cleanup                           # skip resource cleanup
+```
+
+## Best Practices
+
+1. **Naming**: `*_unit_test.tftest.hcl` for plan mode, `*_integration_test.tftest.hcl` for apply mode
+2. **Test naming**: Use descriptive run block names that explain the scenario being tested
+3. **Default to plan**: Use `command = plan` unless you need to test real resource behavior
+4. **Use mocks** for external dependencies — faster and no credentials needed (see `references/MOCK_PROVIDERS.md`)
+5. **Error messages**: Make them specific enough to diagnose failures without running the test again
+6. **Negative tests**: Use `expect_failures` to verify validation rules reject bad inputs
+7. **Variable coverage**: Test different variable combinations to validate all code paths — test variables have the highest precedence and override all other sources
+8. **Module sources**: Test files only support local paths and registry modules — not git or HTTP URLs
+9. **Parallel execution**: Use `parallel = true` for independent tests with different state files
+10. **Cleanup**: Integration tests destroy resources in reverse run block order automatically; use `-no-cleanup` for debugging
+11. **CI/CD**: Run unit tests on every PR, integration tests on merge (see `references/CI_CD.md`)
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Assertion failures | Use `-verbose` to see actual vs expected values |
+| Missing credentials | Use mock providers for unit tests |
+| Unsupported module source | Convert git/HTTP sources to local modules |
+| Tests interfering | Use `state_key` or separate modules for isolation |
+| Slow tests | Use `command = plan` and mocks; run integration tests separately |
+
+## References
+
+- [Terraform Testing Documentation](https://developer.hashicorp.com/terraform/language/tests)
+- [Terraform Test Command](https://developer.hashicorp.com/terraform/cli/commands/test)
+- [Testing Best Practices](https://developer.hashicorp.com/terraform/language/tests/best-practices)

--- a/.agents/skills/terraform-test/references/CI_CD.md
+++ b/.agents/skills/terraform-test/references/CI_CD.md
@@ -1,0 +1,80 @@
+# CI/CD Integration
+
+## GitHub Actions
+
+```yaml
+name: Terraform Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.0
+
+      - run: terraform fmt -check -recursive
+      - run: terraform init
+      - run: terraform validate
+      - name: Run unit tests (plan mode, no credentials needed)
+        run: terraform test -filter=unit_test -verbose
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.0
+
+      - run: terraform init
+      - name: Run integration tests
+        run: terraform test -filter=integration_test -verbose
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+## GitLab CI
+
+```yaml
+stages:
+  - validate
+  - test
+
+terraform-unit-tests:
+  image: hashicorp/terraform:1.9
+  stage: validate
+  before_script:
+    - terraform init
+  script:
+    - terraform fmt -check -recursive
+    - terraform validate
+    - terraform test -filter=unit_test -verbose
+
+terraform-integration-tests:
+  image: hashicorp/terraform:1.9
+  stage: test
+  before_script:
+    - terraform init
+  script:
+    - terraform test -filter=integration_test -verbose
+  only:
+    - main
+```
+
+## Recommended CI Strategy
+
+- Run unit tests (plan mode + mock tests) on every PR — fast, no credentials needed
+- Run integration tests only on merge to main or nightly — requires cloud credentials
+- Use `-filter=unit_test` / `-filter=integration_test` to separate test types based on naming convention
+- Store cloud credentials as CI secrets, never in code

--- a/.agents/skills/terraform-test/references/EXAMPLES.md
+++ b/.agents/skills/terraform-test/references/EXAMPLES.md
@@ -1,0 +1,314 @@
+# Example Test Suite
+
+Complete example testing a VPC module with unit, integration, and mock tests.
+
+## Unit Tests (Plan Mode)
+
+```hcl
+# tests/vpc_module_unit_test.tftest.hcl
+
+variables {
+  environment = "test"
+  aws_region  = "us-west-2"
+}
+
+run "test_defaults" {
+  command = plan
+
+  variables {
+    vpc_cidr = "10.0.0.0/16"
+    vpc_name = "test-vpc"
+  }
+
+  assert {
+    condition     = aws_vpc.main.cidr_block == "10.0.0.0/16"
+    error_message = "VPC CIDR should match input"
+  }
+
+  assert {
+    condition     = aws_vpc.main.enable_dns_hostnames == true
+    error_message = "DNS hostnames should be enabled by default"
+  }
+
+  assert {
+    condition     = aws_vpc.main.tags["Name"] == "test-vpc"
+    error_message = "VPC name tag should match input"
+  }
+}
+
+run "test_subnets" {
+  command = plan
+
+  variables {
+    vpc_cidr        = "10.0.0.0/16"
+    vpc_name        = "test-vpc"
+    public_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
+    private_subnets = ["10.0.10.0/24", "10.0.11.0/24"]
+  }
+
+  assert {
+    condition     = length(aws_subnet.public) == 2
+    error_message = "Should create 2 public subnets"
+  }
+
+  assert {
+    condition     = length(aws_subnet.private) == 2
+    error_message = "Should create 2 private subnets"
+  }
+
+  assert {
+    condition = alltrue([
+      for subnet in aws_subnet.private :
+      subnet.map_public_ip_on_launch == false
+    ])
+    error_message = "Private subnets should not assign public IPs"
+  }
+}
+
+run "test_outputs" {
+  command = plan
+
+  variables {
+    vpc_cidr = "10.0.0.0/16"
+    vpc_name = "test-vpc"
+  }
+
+  assert {
+    condition     = output.vpc_id != ""
+    error_message = "VPC ID output should not be empty"
+  }
+
+  assert {
+    condition     = can(regex("^vpc-", output.vpc_id))
+    error_message = "VPC ID should have correct format"
+  }
+
+  assert {
+    condition     = output.vpc_cidr == "10.0.0.0/16"
+    error_message = "VPC CIDR output should match input"
+  }
+}
+
+run "test_invalid_cidr" {
+  command = plan
+
+  variables {
+    vpc_cidr = "invalid"
+    vpc_name = "test-vpc"
+  }
+
+  expect_failures = [
+    var.vpc_cidr
+  ]
+}
+```
+
+## Integration Tests (Apply Mode)
+
+```hcl
+# tests/vpc_module_integration_test.tftest.hcl
+
+variables {
+  environment = "integration-test"
+  aws_region  = "us-west-2"
+}
+
+run "integration_test_vpc_creation" {
+  # command defaults to apply — creates real AWS resources
+
+  variables {
+    vpc_cidr = "10.100.0.0/16"
+    vpc_name = "integration-test-vpc"
+  }
+
+  assert {
+    condition     = aws_vpc.main.id != ""
+    error_message = "VPC should be created with valid ID"
+  }
+
+  assert {
+    condition     = aws_vpc.main.state == "available"
+    error_message = "VPC should be in available state"
+  }
+}
+```
+
+## Mock Tests (Plan Mode, No Credentials)
+
+```hcl
+# tests/vpc_module_mock_test.tftest.hcl
+
+mock_provider "aws" {
+  mock_resource "aws_instance" {
+    defaults = {
+      id            = "i-1234567890abcdef0"
+      instance_type = "t2.micro"
+      ami           = "ami-12345678"
+      public_ip     = "203.0.113.1"
+      private_ip    = "10.0.1.100"
+    }
+  }
+
+  mock_resource "aws_vpc" {
+    defaults = {
+      id                   = "vpc-12345678"
+      cidr_block           = "10.0.0.0/16"
+      enable_dns_hostnames = true
+      enable_dns_support   = true
+    }
+  }
+
+  mock_resource "aws_subnet" {
+    defaults = {
+      id                      = "subnet-12345678"
+      vpc_id                  = "vpc-12345678"
+      cidr_block              = "10.0.1.0/24"
+      availability_zone       = "us-west-2a"
+      map_public_ip_on_launch = false
+    }
+  }
+
+  mock_data "aws_ami" {
+    defaults = {
+      id   = "ami-0c55b159cbfafe1f0"
+      name = "ubuntu-focal-20.04-amd64"
+    }
+  }
+
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-west-2a", "us-west-2b", "us-west-2c"]
+    }
+  }
+}
+
+run "test_instance_with_mocks" {
+  command = plan
+
+  variables {
+    instance_type = "t2.micro"
+    ami_id        = "ami-12345678"
+  }
+
+  assert {
+    condition     = aws_instance.example.instance_type == "t2.micro"
+    error_message = "Instance type should match input variable"
+  }
+
+  assert {
+    condition     = aws_instance.example.id == "i-1234567890abcdef0"
+    error_message = "Mock should return consistent instance ID"
+  }
+}
+
+run "test_data_source_with_mocks" {
+  command = plan
+
+  assert {
+    condition     = data.aws_ami.ubuntu.id == "ami-0c55b159cbfafe1f0"
+    error_message = "Mock data source should return predictable AMI ID"
+  }
+
+  assert {
+    condition     = length(data.aws_availability_zones.available.names) == 3
+    error_message = "Should return 3 mocked availability zones"
+  }
+
+  assert {
+    condition     = contains(data.aws_availability_zones.available.names, "us-west-2a")
+    error_message = "Should include us-west-2a in mocked zones"
+  }
+}
+
+run "test_outputs_with_mocks" {
+  command = plan
+
+  assert {
+    condition     = output.vpc_id == "vpc-12345678"
+    error_message = "VPC ID output should match mocked value"
+  }
+
+  assert {
+    condition     = can(regex("^vpc-", output.vpc_id))
+    error_message = "VPC ID output should have correct format"
+  }
+}
+
+run "test_conditional_resources_with_mocks" {
+  command = plan
+
+  variables {
+    create_bastion     = true
+    create_nat_gateway = false
+  }
+
+  assert {
+    condition     = length(aws_instance.bastion) == 1
+    error_message = "Bastion should be created when enabled"
+  }
+
+  assert {
+    condition     = length(aws_nat_gateway.nat) == 0
+    error_message = "NAT gateway should not be created when disabled"
+  }
+}
+
+run "test_tag_inheritance_with_mocks" {
+  command = plan
+
+  variables {
+    common_tags = {
+      Environment = "test"
+      ManagedBy   = "Terraform"
+    }
+  }
+
+  assert {
+    condition = alltrue([
+      for key in keys(var.common_tags) :
+      contains(keys(aws_instance.example.tags), key)
+    ])
+    error_message = "All common tags should be present on instance"
+  }
+}
+
+run "test_invalid_cidr_with_mocks" {
+  command = plan
+
+  variables {
+    vpc_cidr = "invalid"
+  }
+
+  expect_failures = [
+    var.vpc_cidr
+  ]
+}
+
+run "setup_vpc_with_mocks" {
+  command = plan
+
+  variables {
+    vpc_cidr = "10.0.0.0/16"
+    vpc_name = "test-vpc"
+  }
+
+  assert {
+    condition     = aws_vpc.main.cidr_block == "10.0.0.0/16"
+    error_message = "VPC CIDR should match input"
+  }
+}
+
+run "test_subnet_references_vpc_with_mocks" {
+  command = plan
+
+  variables {
+    vpc_id      = run.setup_vpc_with_mocks.vpc_id
+    subnet_cidr = "10.0.1.0/24"
+  }
+
+  assert {
+    condition     = aws_subnet.example.vpc_id == run.setup_vpc_with_mocks.vpc_id
+    error_message = "Subnet should reference VPC from previous run"
+  }
+}
+```

--- a/.agents/skills/terraform-test/references/MOCK_PROVIDERS.md
+++ b/.agents/skills/terraform-test/references/MOCK_PROVIDERS.md
@@ -1,0 +1,171 @@
+# Mock Providers
+
+Mock providers simulate provider behavior without creating real infrastructure (Terraform 1.7.0+). Use them for fast, credential-free unit tests.
+
+## Basic Mock Provider
+
+```hcl
+mock_provider "aws" {
+  mock_resource "aws_instance" {
+    defaults = {
+      id            = "i-1234567890abcdef0"
+      instance_type = "t2.micro"
+      ami           = "ami-12345678"
+      public_ip     = "203.0.113.1"
+      private_ip    = "10.0.1.100"
+    }
+  }
+
+  mock_data "aws_ami" {
+    defaults = {
+      id = "ami-0c55b159cbfafe1f0"
+    }
+  }
+
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-west-2a", "us-west-2b", "us-west-2c"]
+    }
+  }
+}
+
+run "test_with_mocks" {
+  command = plan  # Mocks only work with plan mode
+
+  assert {
+    condition     = aws_instance.example.id == "i-1234567890abcdef0"
+    error_message = "Mock instance ID should match"
+  }
+}
+```
+
+## Aliased Mock Provider
+
+```hcl
+mock_provider "aws" {
+  alias = "mocked"
+
+  mock_resource "aws_s3_bucket" {
+    defaults = {
+      id  = "test-bucket-12345"
+      arn = "arn:aws:s3:::test-bucket-12345"
+    }
+  }
+}
+
+run "test_with_aliased_mock" {
+  command = plan
+
+  providers = {
+    aws = provider.aws.mocked
+  }
+
+  assert {
+    condition     = aws_s3_bucket.example.id == "test-bucket-12345"
+    error_message = "Bucket ID should match mock"
+  }
+}
+```
+
+## Common Mock Defaults
+
+```hcl
+mock_provider "aws" {
+  mock_resource "aws_instance" {
+    defaults = {
+      id                          = "i-1234567890abcdef0"
+      arn                         = "arn:aws:ec2:us-west-2:123456789012:instance/i-1234567890abcdef0"
+      instance_type               = "t2.micro"
+      ami                         = "ami-12345678"
+      availability_zone           = "us-west-2a"
+      subnet_id                   = "subnet-12345678"
+      vpc_security_group_ids      = ["sg-12345678"]
+      associate_public_ip_address = true
+      public_ip                   = "203.0.113.1"
+      private_ip                  = "10.0.1.100"
+      tags                        = {}
+    }
+  }
+
+  mock_resource "aws_vpc" {
+    defaults = {
+      id                   = "vpc-12345678"
+      arn                  = "arn:aws:ec2:us-west-2:123456789012:vpc/vpc-12345678"
+      cidr_block           = "10.0.0.0/16"
+      enable_dns_hostnames = true
+      enable_dns_support   = true
+      instance_tenancy     = "default"
+      tags                 = {}
+    }
+  }
+
+  mock_resource "aws_subnet" {
+    defaults = {
+      id                      = "subnet-12345678"
+      arn                     = "arn:aws:ec2:us-west-2:123456789012:subnet/subnet-12345678"
+      vpc_id                  = "vpc-12345678"
+      cidr_block              = "10.0.1.0/24"
+      availability_zone       = "us-west-2a"
+      map_public_ip_on_launch = false
+      tags                    = {}
+    }
+  }
+
+  mock_resource "aws_s3_bucket" {
+    defaults = {
+      id                 = "test-bucket-12345"
+      arn                = "arn:aws:s3:::test-bucket-12345"
+      bucket             = "test-bucket-12345"
+      bucket_domain_name = "test-bucket-12345.s3.amazonaws.com"
+      region             = "us-west-2"
+      tags               = {}
+    }
+  }
+
+  mock_data "aws_ami" {
+    defaults = {
+      id                  = "ami-0c55b159cbfafe1f0"
+      name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210430"
+      architecture        = "x86_64"
+      root_device_type    = "ebs"
+      virtualization_type = "hvm"
+    }
+  }
+
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names    = ["us-west-2a", "us-west-2b", "us-west-2c"]
+      zone_ids = ["usw2-az1", "usw2-az2", "usw2-az3"]
+    }
+  }
+
+  mock_data "aws_vpc" {
+    defaults = {
+      id                   = "vpc-12345678"
+      cidr_block           = "10.0.0.0/16"
+      enable_dns_hostnames = true
+      enable_dns_support   = true
+    }
+  }
+}
+```
+
+## When to Use Mocks
+
+**Good fit:**
+- Testing Terraform logic, conditionals, `for_each`/`count` expressions
+- Validating variable transformations and output calculations
+- Local development without cloud credentials
+- Fast CI/CD feedback loops
+
+**Not a good fit:**
+- Validating actual provider API behavior
+- Testing real resource creation side effects
+- End-to-end integration testing
+
+## Limitations
+
+- **Plan mode only** — mocks don't work with `command = apply`
+- Mock defaults may not reflect real computed attribute values
+- Mocks need manual updates when provider schemas change
+- Can't test real resource dependencies or timing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,8 +277,17 @@ All of the following are present and should stay present:
 [skills CLI](https://skills.sh) and pinned by `skills-lock.json`:
 `terraform-style-guide` and `terraform-test`. Agents that read
 `.agents/skills/` (pi does natively; Claude Code via the git-ignored
-`.claude/skills/` symlinks) load them automatically. Do not hand-edit these
-files; update them with `skills update -p`. Where a skill's generic guidance
+`.claude/skills/` symlinks) load them automatically. The symlinks are not
+committed; Claude Code users create them once per clone:
+
+```bash
+mkdir -p .claude/skills
+ln -sf ../../.agents/skills/terraform-style-guide \
+       ../../.agents/skills/terraform-test .claude/skills/
+```
+
+Do not hand-edit the vendored files; update them with `skills update -p`.
+Where a skill's generic guidance
 conflicts with this repo's conventions (e.g. the style guide's `terraform.tf`
 vs this repo's `versions.tf`, or its Terraform version floor), **this
 `AGENTS.md` and the existing repo layout win**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,19 @@ All of the following are present and should stay present:
 
 ## How to work in this repo (agent quick reference)
 
+### Vendored agent skills
+
+`.agents/skills/` contains two skills vendored from
+[hashicorp/agent-skills](https://github.com/hashicorp/agent-skills) via the
+[skills CLI](https://skills.sh) and pinned by `skills-lock.json`:
+`terraform-style-guide` and `terraform-test`. Agents that read
+`.agents/skills/` (pi does natively; Claude Code via the git-ignored
+`.claude/skills/` symlinks) load them automatically. Do not hand-edit these
+files; update them with `skills update -p`. Where a skill's generic guidance
+conflicts with this repo's conventions (e.g. the style guide's `terraform.tf`
+vs this repo's `versions.tf`, or its Terraform version floor), **this
+`AGENTS.md` and the existing repo layout win**.
+
 ### Local development loop
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ this project adheres to the stability contract in
   API before fixing.
 
 ### Added
+- Vendored two agent skills from
+  [hashicorp/agent-skills](https://github.com/hashicorp/agent-skills) into
+  `.agents/skills/` via the skills CLI, pinned by `skills-lock.json`:
+  `terraform-style-guide` and `terraform-test`. Coding agents working in this
+  repo pick them up automatically; module consumers are unaffected.
 - All five examples (`small`, `medium`, `large`, `cloudflare`, `godaddy`) now
   expose the module's `n8n_image_tag` input as a passthrough variable
   (default `null`, same tag-format validation as the module), so callers can

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "terraform-style-guide": {
+      "source": "hashicorp/agent-skills",
+      "sourceType": "github",
+      "skillPath": "terraform/code-generation/skills/terraform-style-guide/SKILL.md",
+      "computedHash": "e7776668ff288f856a8f9bb8bb3301dd2c78c70102d81fb1027c059b01f6b07b"
+    },
+    "terraform-test": {
+      "source": "hashicorp/agent-skills",
+      "sourceType": "github",
+      "skillPath": "terraform/code-generation/skills/terraform-test/SKILL.md",
+      "computedHash": "c446a090ac98bea46704c16003761a030e6aa56a27b0e95d6914fbdb7c1d2a23"
+    }
+  }
+}


### PR DESCRIPTION
## What

Vendors two agent skills from [hashicorp/agent-skills](https://github.com/hashicorp/agent-skills) into `.agents/skills/` via the [skills CLI](https://skills.sh), pinned by `skills-lock.json`:

- `terraform-style-guide` - HashiCorp's official HCL style conventions
- `terraform-test` - writing and running `.tftest.hcl` suites (with mock provider, CI/CD, and example references)

## Why

These two skills map directly to this repo's daily work and quality bar (style conventions and `terraform test` suites). Committing them means every contributor's coding agent picks them up automatically instead of relying on per-machine global installs.

## How it wires up

- Pi discovers `.agents/skills/` natively; Claude Code uses `.claude/skills/` symlinks, which stay git-ignored (local-only).
- `skills-lock.json` pins source and content hashes; update with `skills update -p`.
- `AGENTS.md` documents provenance, the update path, and that repo conventions win where the skills' generic guidance conflicts (e.g. `versions.tf` vs the style guide's `terraform.tf`, Terraform version floor).
- Content reviewed before commit: benign HashiCorp reference markdown (MPL-2.0), ~48 KB. Skills CLI risk scans report Safe / 0 alerts / Low Risk.
- No `.tf` changes, so no impact on module consumers, terraform-docs output, or the test matrix. The Terraform Registry ignores dotdirs.