### PR TITLE
feat: add redis_transit_encryption_enabled for ElastiCache TLS + AUTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,51 @@ this project adheres to the stability contract in
 
 ### Added
 
+- `redis_transit_encryption_enabled` input (default `false`) puts the
+  ElastiCache queue backend behind TLS and an AUTH token. The default preserves
+  the module's network-trust posture — Redis in private subnets behind a
+  VPC-only security group — so callers who leave it alone get no plan diff at
+  all. Callers who want credential-based Redis security flip one switch instead
+  of forking the module. Resolves
+  [#41](https://github.com/n8n-io/terraform-aws-n8n/issues/41).
+
+  The opt-in path uses a **different AWS resource**, which is worth
+  understanding before enabling it. `auth_token` does not exist on
+  `aws_elasticache_cluster`; AWS exposes it only on
+  `aws_elasticache_replication_group`, and further requires transit encryption
+  to be on before AUTH can be enabled at all. So the module now carries both
+  resources, count-gated on the variable and mutually exclusive: the default
+  path keeps the `aws_elasticache_cluster` it has always used, and only the
+  opt-in path creates a replication group (single node, `num_cache_clusters =
+  1`, matching the cluster path's topology and cost). Everything downstream —
+  Helm values, KEDA triggers, the `redis_endpoint` output — reads a shared
+  `local.redis_host` rather than either resource, so the two paths cannot
+  drift.
+
+  **Switching the flag on an existing deployment replaces Redis**, since the
+  two resources are different objects. Every job queued at that moment is lost.
+  Drain workers and pick a maintenance window. Upgrading the module *without*
+  touching the variable does **not** replace anything: a `moved` block in
+  `refactoring.tf` absorbs the `count` added to `aws_elasticache_cluster.n8n`.
+  Verified on a live cluster — a deployment applied on the previous version and
+  then repointed at this one planned `No changes.`
+
+  The generated token respects ElastiCache's constraints (16-128 chars, with
+  `! & # $ ^ < > -` the only permitted non-alphanumerics) and is published two
+  ways: as a Kubernetes secret the chart mounts as `QUEUE_BULL_REDIS_PASSWORD`
+  on main, worker and webhook processor, and as a new sensitive
+  `redis_auth_token` output (`terraform output -raw redis_auth_token`).
+
+  **Known limitation:** KEDA's worker autoscaler does not yet authenticate to
+  Redis. Its trigger carries neither TLS nor credentials, so while this flag is
+  on, queue-depth autoscaling stops responding to backlog and workers hold a
+  static count between `n8n_worker_keda_min_replicas` and
+  `n8n_worker_keda_max_replicas`. Nothing crashes, which is what makes it easy
+  to miss. Tracked in
+  [#66](https://github.com/n8n-io/terraform-aws-n8n/issues/66); until that
+  lands, treat this flag as trading queue-depth autoscaling for encryption and
+  authentication.
+
 - `n8n_license_detach_floating_on_shutdown` input (default `false`) maps to
   `N8N_LICENSE_DETACH_FLOATING_ON_SHUTDOWN`, overriding n8n's own upstream
   default of `true`. In multi-main (the module default), the leader main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,12 +87,24 @@ this project adheres to the stability contract in
   on main, worker and webhook processor, and as a new sensitive
   `redis_auth_token` output (`terraform output -raw redis_auth_token`).
 
-  **Known limitation:** KEDA's worker autoscaler does not yet authenticate to
-  Redis. Its trigger carries neither TLS nor credentials, so while this flag is
-  on, queue-depth autoscaling stops responding to backlog and workers hold a
-  static count between `n8n_worker_keda_min_replicas` and
-  `n8n_worker_keda_max_replicas`. Nothing crashes, which is what makes it easy
-  to miss. Tracked in
+  The two paths deliberately use **different ElastiCache identifiers**
+  (`<cluster_name>-redis` and `<cluster_name>-redis-tls`). ElastiCache shares a
+  single identifier namespace between cache clusters and replication groups, and
+  the two Terraform resources have no dependency on each other, so reusing one
+  name let Terraform destroy the old cache and then fail to create its
+  replacement — leaving the deployment with no queue backend and requiring a
+  second apply to recover. Distinct names make enabling and disabling the flag
+  single-apply operations in both directions. Found by applying against a live
+  cluster; a plan-time test cannot see it.
+
+  **Known limitation:** KEDA's worker autoscaler cannot reach an encrypted
+  Redis. Its trigger carries neither TLS nor credentials, so it opens a
+  plaintext connection to the TLS-only endpoint and hangs — the operator logs
+  `connection to redis failed: i/o timeout` and the generated HPA reports its
+  queue-depth metric as `<unknown>`. Workers then hold their current replica
+  count within `n8n_worker_keda_min_replicas` / `n8n_worker_keda_max_replicas`
+  instead of tracking backlog. n8n itself is unaffected and nothing crashes,
+  which is what makes it easy to miss. Tracked in
   [#66](https://github.com/n8n-io/terraform-aws-n8n/issues/66); until that
   lands, treat this flag as trading queue-depth autoscaling for encryption and
   authentication.

--- a/README.md
+++ b/README.md
@@ -425,6 +425,67 @@ env vars are emitted and n8n's OpenTelemetry SDK is not loaded.
 `n8n_otel_exporter_otlp_headers` is marked `sensitive` because it typically
 carries collector authentication tokens.
 
+## Redis in-transit encryption and AUTH
+
+By default the module secures its ElastiCache queue backend by **network
+boundary**: Redis sits in private subnets behind a security group that admits
+only VPC traffic, with no TLS and no credentials. That is a defensible posture
+inside a trusted VPC and it is the module's accepted as-built behaviour, but it
+leaves two things open — queue payloads (workflow execution data) cross the VPC
+in cleartext, and anything that reaches the network boundary reaches Redis
+unauthenticated.
+
+Set `redis_transit_encryption_enabled = true` to close both. The module then
+enables TLS in transit, generates an AUTH token, publishes it as a Kubernetes
+secret, and wires `QUEUE_BULL_REDIS_TLS` plus `QUEUE_BULL_REDIS_PASSWORD` onto
+every n8n container. Retrieve the token with:
+
+```console
+$ terraform output -raw redis_auth_token
+```
+
+### It swaps the underlying AWS resource
+
+`auth_token` is not available on `aws_elasticache_cluster` — AWS exposes it only
+on `aws_elasticache_replication_group`, and only when transit encryption is
+already enabled. The module therefore carries both resources, mutually
+exclusive:
+
+| `redis_transit_encryption_enabled` | Resource created |
+| --- | --- |
+| `false` (default) | `aws_elasticache_cluster.n8n[0]` |
+| `true` | `aws_elasticache_replication_group.n8n[0]` |
+
+Both are single-node with the same `redis_node_type`, so enabling the flag does
+not change the topology or the bill. The endpoint shape changes (a cache node
+address becomes a replication group primary endpoint), which is why everything
+downstream reads the module's internal `redis_host` local and why the
+`redis_endpoint` output stays correct either way.
+
+> [!WARNING]
+> **Changing this on an existing deployment replaces Redis.** The two resources
+> are different objects, so flipping the flag destroys one and creates the
+> other, dropping every job queued at that moment. Drain workers and use a
+> maintenance window.
+>
+> Upgrading the module *without* touching this variable replaces nothing — a
+> `moved` block absorbs the `count` added to the cluster resource. Existing
+> deployments plan `No changes.`
+
+### Known limitation: worker autoscaling
+
+KEDA's worker autoscaler does not yet authenticate to Redis. Its trigger carries
+neither TLS nor credentials, so while this flag is on, KEDA cannot read queue
+depth: **workers stop scaling on backlog** and hold a static count between
+`n8n_worker_keda_min_replicas` and `n8n_worker_keda_max_replicas`. Nothing
+crashes and the pods stay healthy, which is what makes this easy to miss.
+
+Until [#66](https://github.com/n8n-io/terraform-aws-n8n/issues/66) lands, this
+flag trades queue-depth autoscaling for encryption and authentication. If your
+workload relies on bursty queue-driven scaling, either stay on the default
+posture or raise `n8n_worker_keda_min_replicas` to cover peak while the flag is
+on.
+
 ## Log streaming (Enterprise)
 
 Set `n8n_log_streaming_managed_by_env = true` to provision n8n's
@@ -512,6 +573,7 @@ No modules.
 | [aws_eks_pod_identity_association.lbc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_elasticache_cluster.n8n](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster) | resource |
+| [aws_elasticache_replication_group.n8n](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
 | [aws_elasticache_subnet_group.n8n](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.lbc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -551,9 +613,11 @@ No modules.
 | [kubernetes_namespace.n8n](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_secret.n8n](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.n8n_db](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.n8n_redis](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_storage_class_v1.gp3](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
 | [random_id.n8n_encryption_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_password.db_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.redis_auth_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.task_runner_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [time_sleep.wait_for_alb_cleanup](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -656,6 +720,7 @@ No modules.
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | IDs of private subnets (one per AZ, minimum two AZs). RDS, ElastiCache, and EKS nodes attach here. | `list(string)` | n/a | yes |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | IDs of public subnets (one per AZ, minimum two AZs). The ALB attaches here. | `list(string)` | n/a | yes |
 | <a name="input_redis_node_type"></a> [redis\_node\_type](#input\_redis\_node\_type) | ElastiCache node type (cache.t3.medium ~$25/month) | `string` | `"cache.t3.medium"` | no |
+| <a name="input_redis_transit_encryption_enabled"></a> [redis\_transit\_encryption\_enabled](#input\_redis\_transit\_encryption\_enabled) | Encrypt the n8n queue backend in transit and require an AUTH token on it. Defaults to false, which is the module's deliberate network-trust posture: Redis sits in private subnets behind a security group that admits only VPC traffic, so isolation is by network boundary rather than by credentials. Set true to add TLS plus a generated AUTH token on top of that boundary — worth doing when queue payloads (workflow execution data) crossing the VPC in cleartext, or an unauthenticated Redis after a network-boundary breach, are risks you need closed. CHANGING THIS ON AN EXISTING DEPLOYMENT REPLACES REDIS: AWS exposes the AUTH token only on aws\_elasticache\_replication\_group, so the opt-in path uses that resource while the default path keeps aws\_elasticache\_cluster. Flipping the value destroys one and creates the other, which drops every job queued at that moment — drain workers and pick a maintenance window. KNOWN LIMITATION: KEDA's worker autoscaler has no TLS or credentials on its Redis trigger yet, so while this is true, queue-depth autoscaling stops responding to backlog and workers hold a static count between n8n\_worker\_keda\_min\_replicas and n8n\_worker\_keda\_max\_replicas. Tracked in https://github.com/n8n-io/terraform-aws-n8n/issues/66. | `bool` | `false` | no |
 | <a name="input_route53_zone_id"></a> [route53\_zone\_id](#input\_route53\_zone\_id) | Route53 hosted zone ID for the parent of n8n\_domain (e.g. the zone for example.com if n8n\_domain = n8n.example.com). When set, the module issues a DNS-validated ACM certificate and creates the alias A-record automatically — single terraform apply, no manual DNS steps. Leave null and pass certificate\_arn instead. Set exactly one of certificate\_arn or route53\_zone\_id. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional AWS tags to apply to all resources this module creates. Merged on top of the built-in ManagedBy/Project tags. | `map(string)` | `{}` | no |
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | CIDR block of the VPC — used by the RDS and Redis security groups to allow intra-VPC traffic. | `string` | n/a | yes |
@@ -681,7 +746,8 @@ No modules.
 | <a name="output_n8n_webhook_service_name"></a> [n8n\_webhook\_service\_name](#output\_n8n\_webhook\_service\_name) | Name of the Kubernetes Service fronting the n8n webhook processors, on port 5678. Production webhooks are disabled on the main pods, so a bring-your-own Ingress must route /webhook here. |
 | <a name="output_namespace"></a> [namespace](#output\_namespace) | Kubernetes namespace n8n is deployed into. |
 | <a name="output_rds_endpoint"></a> [rds\_endpoint](#output\_rds\_endpoint) | Database endpoint — module-managed RDS when create\_database = true, or the value of var.db\_host when using an external database (e.g. Aurora). |
-| <a name="output_redis_endpoint"></a> [redis\_endpoint](#output\_redis\_endpoint) | ElastiCache Redis endpoint |
+| <a name="output_redis_auth_token"></a> [redis\_auth\_token](#output\_redis\_auth\_token) | ElastiCache AUTH token when redis\_transit\_encryption\_enabled = true; null otherwise, since the default posture has no credential. Retrieve with: terraform output -raw redis\_auth\_token |
+| <a name="output_redis_endpoint"></a> [redis\_endpoint](#output\_redis\_endpoint) | ElastiCache Redis endpoint — the cache node address when redis\_transit\_encryption\_enabled = false, or the replication group's primary endpoint when true. Reached over TLS and requiring the AUTH token in the latter case. |
 | <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | S3 bucket used for n8n binary storage |
 <!-- END_TF_DOCS -->
 

--- a/README.md
+++ b/README.md
@@ -474,11 +474,16 @@ downstream reads the module's internal `redis_host` local and why the
 
 ### Known limitation: worker autoscaling
 
-KEDA's worker autoscaler does not yet authenticate to Redis. Its trigger carries
-neither TLS nor credentials, so while this flag is on, KEDA cannot read queue
-depth: **workers stop scaling on backlog** and hold a static count between
-`n8n_worker_keda_min_replicas` and `n8n_worker_keda_max_replicas`. Nothing
-crashes and the pods stay healthy, which is what makes this easy to miss.
+KEDA's worker autoscaler cannot reach an encrypted Redis. Its trigger is
+configured with neither TLS nor credentials, so it opens a plaintext connection
+to a TLS-only endpoint and hangs until it times out — the KEDA operator logs
+`connection to redis failed: i/o timeout`, and the generated HPA reports its
+queue-depth metric as `<unknown>`.
+
+The practical effect: **workers stop scaling on backlog** and hold whatever
+replica count they currently have, bounded by `n8n_worker_keda_min_replicas` and
+`n8n_worker_keda_max_replicas`. Nothing crashes, n8n itself is unaffected, and
+the pods stay healthy — which is exactly what makes this easy to miss.
 
 Until [#66](https://github.com/n8n-io/terraform-aws-n8n/issues/66) lands, this
 flag trades queue-depth autoscaling for encryption and authentication. If your

--- a/locals.tf
+++ b/locals.tf
@@ -89,6 +89,22 @@ locals {
 
   ingress_annotations = merge(local.ingress_default_annotations, var.ingress_annotations)
 
+  # Redis endpoint, abstracted over the two mutually exclusive engine resources
+  # in redis.tf (see the comment there for why there are two). Everything that
+  # needs to reach the queue — the Helm values, the KEDA triggers, the
+  # redis_endpoint output — reads this rather than picking a resource, so the
+  # two paths cannot drift apart.
+  #
+  # Branching on the variable rather than try()/coalesce() over both resources:
+  # the variable is known at plan time, so the unselected resource's [0] is
+  # never indexed. try() would also mask a genuine error in the live branch as
+  # a silent fallback to the dead one.
+  redis_host = var.redis_transit_encryption_enabled ? (
+    aws_elasticache_replication_group.n8n[0].primary_endpoint_address
+    ) : (
+    aws_elasticache_cluster.n8n[0].cache_nodes[0].address
+  )
+
   common_tags = merge(
     {
       ManagedBy = "terraform"

--- a/n8n.tf
+++ b/n8n.tf
@@ -76,6 +76,33 @@ resource "kubernetes_secret" "n8n_redis" {
   }
 }
 
+resource "kubernetes_manifest" "keda_redis_trigger_auth" {
+  count = var.redis_transit_encryption_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "keda.sh/v1alpha1"
+    kind       = "TriggerAuthentication"
+    metadata = {
+      name      = "n8n-redis-trigger-auth"
+      namespace = kubernetes_namespace.n8n.metadata[0].name
+    }
+    spec = {
+      secretTargetRef = [
+        {
+          parameter = "password"
+          name      = kubernetes_secret.n8n_redis[0].metadata[0].name
+          key       = "password"
+        }
+      ]
+    }
+  }
+
+  depends_on = [
+    helm_release.keda,
+    kubernetes_secret.n8n_redis,
+  ]
+}
+
 # ── Helm release ──────────────────────────────────────────────────────────────
 
 resource "helm_release" "n8n" {
@@ -205,18 +232,6 @@ resource "helm_release" "n8n" {
     # workers waiting for a task runner). KEDA takes the MAX of both.
     # Webhook processor HPA is created externally in scaling.tf (chart skips it
     # when keda.enabled = true).
-    #
-    # KNOWN GAP when redis_transit_encryption_enabled = true: these triggers
-    # carry neither TLS nor credentials. Observed on a live cluster, the first
-    # thing to break is TLS, not auth — KEDA opens a plaintext connection to the
-    # TLS-only endpoint and hangs (`connection to redis failed: i/o timeout`),
-    # so it never gets far enough to be rejected for missing credentials. The
-    # HPA then reports its metric as <unknown> and workers hold their current
-    # replica count. Nothing crashes, which is what makes it easy to miss.
-    #
-    # Fixing it needs `enableTLS` in this metadata block first, then credentials
-    # via either a TriggerAuthentication CRD or a passwordFromEnv indirection —
-    # see https://github.com/n8n-io/terraform-aws-n8n/issues/66.
     keda = {
       enabled = true
       worker = {
@@ -227,21 +242,27 @@ resource "helm_release" "n8n" {
         triggers = [
           {
             type = "redis"
-            metadata = {
-              address    = "${local.redis_host}:6379"
-              listName   = "bull:jobs:wait"
-              listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
-            }
-            authenticationRef = { name = "" }
+            metadata = merge(
+              {
+                address    = "${local.redis_host}:6379"
+                listName   = "bull:jobs:wait"
+                listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
+              },
+              var.redis_transit_encryption_enabled ? { enableTLS = "true" } : {}
+            )
+            authenticationRef = { name = var.redis_transit_encryption_enabled ? "n8n-redis-trigger-auth" : "" }
           },
           {
             type = "redis"
-            metadata = {
-              address    = "${local.redis_host}:6379"
-              listName   = "bull:jobs:active"
-              listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
-            }
-            authenticationRef = { name = "" }
+            metadata = merge(
+              {
+                address    = "${local.redis_host}:6379"
+                listName   = "bull:jobs:active"
+                listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
+              },
+              var.redis_transit_encryption_enabled ? { enableTLS = "true" } : {}
+            )
+            authenticationRef = { name = var.redis_transit_encryption_enabled ? "n8n-redis-trigger-auth" : "" }
           }
         ]
       }

--- a/n8n.tf
+++ b/n8n.tf
@@ -58,6 +58,24 @@ resource "kubernetes_secret" "n8n_db" {
   }
 }
 
+# The ElastiCache AUTH token, on the same shape as the DB secret above. The
+# chart mounts it as QUEUE_BULL_REDIS_PASSWORD on main, worker and webhook
+# processor via redis.passwordSecret (see the Helm values below). Exists only on
+# the opt-in path — there is no token to hold otherwise.
+
+resource "kubernetes_secret" "n8n_redis" {
+  count = var.redis_transit_encryption_enabled ? 1 : 0
+
+  metadata {
+    name      = "n8n-enterprise-redis-secret"
+    namespace = kubernetes_namespace.n8n.metadata[0].name
+  }
+
+  data = {
+    password = random_password.redis_auth_token[0].result
+  }
+}
+
 # ── Helm release ──────────────────────────────────────────────────────────────
 
 resource "helm_release" "n8n" {
@@ -113,13 +131,26 @@ resource "helm_release" "n8n" {
       }
     }
 
-    redis = {
+    # passwordSecret is merged in rather than set inline so the default path
+    # renders exactly the four keys it always has. The chart's default for it is
+    # null and its templates guard on `if and .name .key`, so an omitted key and
+    # an explicit null behave the same — but omitting it keeps the rendered
+    # values byte-identical for existing releases, which is what makes the
+    # upgrade a no-op rather than a Helm diff.
+    redis = merge({
       enabled     = true
       useExternal = true
-      host        = aws_elasticache_cluster.n8n.cache_nodes[0].address
+      host        = local.redis_host
       port        = 6379
-      tls         = false
-    }
+      tls         = var.redis_transit_encryption_enabled
+      },
+      var.redis_transit_encryption_enabled ? {
+        passwordSecret = {
+          name = kubernetes_secret.n8n_redis[0].metadata[0].name
+          key  = "password"
+        }
+      } : {}
+    )
 
     s3 = {
       enabled = true
@@ -174,6 +205,14 @@ resource "helm_release" "n8n" {
     # workers waiting for a task runner). KEDA takes the MAX of both.
     # Webhook processor HPA is created externally in scaling.tf (chart skips it
     # when keda.enabled = true).
+    #
+    # KNOWN GAP when redis_transit_encryption_enabled = true: these triggers
+    # carry neither TLS nor credentials, so against a TLS+AUTH Redis the
+    # queue-depth read fails and workers hold a static count between
+    # minReplicaCount and maxReplicaCount. Nothing crashes, which is what makes
+    # it easy to miss. KEDA takes credentials via a TriggerAuthentication CRD or
+    # a passwordFromEnv indirection, neither of which is wired yet — see
+    # https://github.com/n8n-io/terraform-aws-n8n/issues/66.
     keda = {
       enabled = true
       worker = {
@@ -185,7 +224,7 @@ resource "helm_release" "n8n" {
           {
             type = "redis"
             metadata = {
-              address    = "${aws_elasticache_cluster.n8n.cache_nodes[0].address}:6379"
+              address    = "${local.redis_host}:6379"
               listName   = "bull:jobs:wait"
               listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
             }
@@ -194,7 +233,7 @@ resource "helm_release" "n8n" {
           {
             type = "redis"
             metadata = {
-              address    = "${aws_elasticache_cluster.n8n.cache_nodes[0].address}:6379"
+              address    = "${local.redis_host}:6379"
               listName   = "bull:jobs:active"
               listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
             }
@@ -435,7 +474,10 @@ resource "helm_release" "n8n" {
     helm_release.lbc,
     helm_release.keda,
     aws_db_instance.n8n, # no-op (empty list) when create_database = false
+    # Exactly one of these two is ever non-empty; the other is an empty list and
+    # contributes no edge. See redis.tf.
     aws_elasticache_cluster.n8n,
+    aws_elasticache_replication_group.n8n,
     aws_iam_role_policy_attachment.s3,
     aws_eks_pod_identity_association.s3,
   ]

--- a/n8n.tf
+++ b/n8n.tf
@@ -207,12 +207,16 @@ resource "helm_release" "n8n" {
     # when keda.enabled = true).
     #
     # KNOWN GAP when redis_transit_encryption_enabled = true: these triggers
-    # carry neither TLS nor credentials, so against a TLS+AUTH Redis the
-    # queue-depth read fails and workers hold a static count between
-    # minReplicaCount and maxReplicaCount. Nothing crashes, which is what makes
-    # it easy to miss. KEDA takes credentials via a TriggerAuthentication CRD or
-    # a passwordFromEnv indirection, neither of which is wired yet — see
-    # https://github.com/n8n-io/terraform-aws-n8n/issues/66.
+    # carry neither TLS nor credentials. Observed on a live cluster, the first
+    # thing to break is TLS, not auth — KEDA opens a plaintext connection to the
+    # TLS-only endpoint and hangs (`connection to redis failed: i/o timeout`),
+    # so it never gets far enough to be rejected for missing credentials. The
+    # HPA then reports its metric as <unknown> and workers hold their current
+    # replica count. Nothing crashes, which is what makes it easy to miss.
+    #
+    # Fixing it needs `enableTLS` in this metadata block first, then credentials
+    # via either a TriggerAuthentication CRD or a passwordFromEnv indirection —
+    # see https://github.com/n8n-io/terraform-aws-n8n/issues/66.
     keda = {
       enabled = true
       worker = {

--- a/n8n.tf
+++ b/n8n.tf
@@ -76,33 +76,6 @@ resource "kubernetes_secret" "n8n_redis" {
   }
 }
 
-resource "kubernetes_manifest" "keda_redis_trigger_auth" {
-  count = var.redis_transit_encryption_enabled ? 1 : 0
-
-  manifest = {
-    apiVersion = "keda.sh/v1alpha1"
-    kind       = "TriggerAuthentication"
-    metadata = {
-      name      = "n8n-redis-trigger-auth"
-      namespace = kubernetes_namespace.n8n.metadata[0].name
-    }
-    spec = {
-      secretTargetRef = [
-        {
-          parameter = "password"
-          name      = kubernetes_secret.n8n_redis[0].metadata[0].name
-          key       = "password"
-        }
-      ]
-    }
-  }
-
-  depends_on = [
-    helm_release.keda,
-    kubernetes_secret.n8n_redis,
-  ]
-}
-
 # ── Helm release ──────────────────────────────────────────────────────────────
 
 resource "helm_release" "n8n" {
@@ -232,6 +205,18 @@ resource "helm_release" "n8n" {
     # workers waiting for a task runner). KEDA takes the MAX of both.
     # Webhook processor HPA is created externally in scaling.tf (chart skips it
     # when keda.enabled = true).
+    #
+    # KNOWN GAP when redis_transit_encryption_enabled = true: these triggers
+    # carry neither TLS nor credentials. Observed on a live cluster, the first
+    # thing to break is TLS, not auth — KEDA opens a plaintext connection to the
+    # TLS-only endpoint and hangs (`connection to redis failed: i/o timeout`),
+    # so it never gets far enough to be rejected for missing credentials. The
+    # HPA then reports its metric as <unknown> and workers hold their current
+    # replica count. Nothing crashes, which is what makes it easy to miss.
+    #
+    # Fixing it needs `enableTLS` in this metadata block first, then credentials
+    # via either a TriggerAuthentication CRD or a passwordFromEnv indirection —
+    # see https://github.com/n8n-io/terraform-aws-n8n/issues/66.
     keda = {
       enabled = true
       worker = {
@@ -242,27 +227,21 @@ resource "helm_release" "n8n" {
         triggers = [
           {
             type = "redis"
-            metadata = merge(
-              {
-                address    = "${local.redis_host}:6379"
-                listName   = "bull:jobs:wait"
-                listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
-              },
-              var.redis_transit_encryption_enabled ? { enableTLS = "true" } : {}
-            )
-            authenticationRef = { name = var.redis_transit_encryption_enabled ? "n8n-redis-trigger-auth" : "" }
+            metadata = {
+              address    = "${local.redis_host}:6379"
+              listName   = "bull:jobs:wait"
+              listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
+            }
+            authenticationRef = { name = "" }
           },
           {
             type = "redis"
-            metadata = merge(
-              {
-                address    = "${local.redis_host}:6379"
-                listName   = "bull:jobs:active"
-                listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
-              },
-              var.redis_transit_encryption_enabled ? { enableTLS = "true" } : {}
-            )
-            authenticationRef = { name = var.redis_transit_encryption_enabled ? "n8n-redis-trigger-auth" : "" }
+            metadata = {
+              address    = "${local.redis_host}:6379"
+              listName   = "bull:jobs:active"
+              listLength = tostring(var.n8n_worker_keda_jobs_per_replica)
+            }
+            authenticationRef = { name = "" }
           }
         ]
       }

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,8 +61,14 @@ output "rds_endpoint" {
 }
 
 output "redis_endpoint" {
-  description = "ElastiCache Redis endpoint"
-  value       = aws_elasticache_cluster.n8n.cache_nodes[0].address
+  description = "ElastiCache Redis endpoint — the cache node address when redis_transit_encryption_enabled = false, or the replication group's primary endpoint when true. Reached over TLS and requiring the AUTH token in the latter case."
+  value       = local.redis_host
+}
+
+output "redis_auth_token" {
+  description = "ElastiCache AUTH token when redis_transit_encryption_enabled = true; null otherwise, since the default posture has no credential. Retrieve with: terraform output -raw redis_auth_token"
+  value       = var.redis_transit_encryption_enabled ? random_password.redis_auth_token[0].result : null
+  sensitive   = true
 }
 
 output "s3_bucket_name" {

--- a/redis.tf
+++ b/redis.tf
@@ -89,7 +89,26 @@ resource "aws_elasticache_cluster" "n8n" {
 resource "aws_elasticache_replication_group" "n8n" {
   count = var.redis_transit_encryption_enabled ? 1 : 0
 
-  replication_group_id = "${local.cluster_name}-redis"
+  # Deliberately NOT "<cluster_name>-redis", which is what the cluster above
+  # uses. ElastiCache shares one identifier namespace between cache clusters and
+  # replication groups, and rejects a second resource reusing the name:
+  #
+  #   InvalidParameterValue: Cannot have a cluster and replication group with
+  #   same identifier. Please use a different identifier.
+  #
+  # These are two independent resources, so Terraform is free to create this one
+  # while the cluster still exists. With a shared name, flipping the variable
+  # destroys the old cache and then fails to create the replacement, leaving the
+  # deployment with no queue backend at all and needing a second apply to
+  # recover. Confirmed against a live cluster, not reasoned about — the failed
+  # apply is what put this comment here.
+  #
+  # A distinct suffix removes the ordering hazard in both directions, so
+  # enabling and disabling the flag are both single-apply operations.
+  #
+  # Length: replication group IDs cap at 40 characters. cluster_name is capped
+  # at 14 by its own validation, so 14 + 10 = 24 leaves ample headroom.
+  replication_group_id = "${local.cluster_name}-redis-tls"
   description          = "n8n queue backend (TLS + AUTH) for ${local.cluster_name}"
   engine               = "redis"
   engine_version       = "7.1"
@@ -112,5 +131,5 @@ resource "aws_elasticache_replication_group" "n8n" {
   # breaking every pod that has not yet been restarted with the new value.
   auth_token_update_strategy = "ROTATE"
 
-  tags = merge(local.common_tags, { Name = "${local.cluster_name}-redis" })
+  tags = merge(local.common_tags, { Name = "${local.cluster_name}-redis-tls" })
 }

--- a/redis.tf
+++ b/redis.tf
@@ -24,6 +24,8 @@ resource "aws_security_group" "redis" {
 }
 
 # ── Subnet group ──────────────────────────────────────────────────────────────
+# Shared by both engine resources below — only the engine swaps with
+# var.redis_transit_encryption_enabled, not the placement or the firewall.
 
 resource "aws_elasticache_subnet_group" "n8n" {
   name       = "n8n-redis-subnet-group-${local.cluster_name}"
@@ -32,11 +34,45 @@ resource "aws_elasticache_subnet_group" "n8n" {
   tags = merge(local.common_tags, { Name = "n8n-redis-subnet-group-${local.cluster_name}" })
 }
 
-# ── ElastiCache Redis cluster ─────────────────────────────────────────────────
+# ── AUTH token ────────────────────────────────────────────────────────────────
+# Only generated on the opt-in path. random_password.db_password and
+# random_password.task_runner_token are both unconditional, but this one is
+# count-gated deliberately: the contract for this feature is that a caller who
+# leaves redis_transit_encryption_enabled at its default sees NO plan diff, and
+# an unconditional random_password would still render `Plan: 1 to add`.
+#
+# ElastiCache AUTH constraints: 16-128 printable characters, and the only
+# permitted non-alphanumerics are ! & # $ ^ < > - — a broader special set (the
+# one db_password uses) is rejected at create time.
+# https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth.html
+
+resource "random_password" "redis_auth_token" {
+  count = var.redis_transit_encryption_enabled ? 1 : 0
+
+  length           = 64
+  special          = true
+  override_special = "!&#$^<>-"
+}
+
+# ── ElastiCache Redis ─────────────────────────────────────────────────────────
 # n8n uses Redis as the queue backend for distributing workflow executions
 # between worker pods, and for coordinating multi-main instances.
+#
+# Two mutually exclusive resources back one logical cache, because AWS splits
+# the capability across resource types: auth_token exists ONLY on
+# aws_elasticache_replication_group, and AWS further requires transit
+# encryption to be on before AUTH can be enabled at all. There is no argument
+# combination that puts an AUTH token on aws_elasticache_cluster.
+#
+# Migrating everyone to the replication group would have been simpler to read,
+# but it replaces the cache for every existing deployment — so the default path
+# keeps the cluster resource it has always used, and only callers who opt in
+# take the replacement. Consumers read local.redis_host rather than either
+# resource directly.
 
 resource "aws_elasticache_cluster" "n8n" {
+  count = var.redis_transit_encryption_enabled ? 0 : 1
+
   # ElastiCache cluster IDs are capped at 20 characters.
   # Pattern: <cluster_name>-redis keeps us within budget for cluster names up to 14 chars.
   cluster_id         = "${local.cluster_name}-redis"
@@ -46,6 +82,35 @@ resource "aws_elasticache_cluster" "n8n" {
   num_cache_nodes    = 1
   subnet_group_name  = aws_elasticache_subnet_group.n8n.name
   security_group_ids = [aws_security_group.redis.id]
+
+  tags = merge(local.common_tags, { Name = "${local.cluster_name}-redis" })
+}
+
+resource "aws_elasticache_replication_group" "n8n" {
+  count = var.redis_transit_encryption_enabled ? 1 : 0
+
+  replication_group_id = "${local.cluster_name}-redis"
+  description          = "n8n queue backend (TLS + AUTH) for ${local.cluster_name}"
+  engine               = "redis"
+  engine_version       = "7.1"
+  node_type            = var.redis_node_type
+  port                 = 6379
+  subnet_group_name    = aws_elasticache_subnet_group.n8n.name
+  security_group_ids   = [aws_security_group.redis.id]
+
+  # Single node with no replica and no automatic failover, matching the cluster
+  # path exactly. This variable buys encryption and authentication; it must not
+  # quietly also buy a second node and double the bill. Availability is a
+  # separate decision and belongs behind its own input.
+  num_cache_clusters = 1
+
+  transit_encryption_enabled = true
+  auth_token                 = random_password.redis_auth_token[0].result
+
+  # Unused on create; declared so a later token change rotates (both the old
+  # and new token valid during the roll) instead of cutting over instantly and
+  # breaking every pod that has not yet been restarted with the new value.
+  auth_token_update_strategy = "ROTATE"
 
   tags = merge(local.common_tags, { Name = "${local.cluster_name}-redis" })
 }

--- a/refactoring.tf
+++ b/refactoring.tf
@@ -33,3 +33,16 @@ moved {
   from = kubernetes_ingress_v1.n8n
   to   = kubernetes_ingress_v1.n8n[0]
 }
+
+# redis_transit_encryption_enabled. The default (false) path still creates this
+# cluster; the opt-in path creates an aws_elasticache_replication_group instead,
+# that being the only ElastiCache resource AWS lets you attach an auth_token to.
+#
+# Without this block the added count reads as a new address and every existing
+# deployment replaces its Redis on upgrade — including callers who never set the
+# new variable. Losing the queue is not a cosmetic regression: in-flight
+# executions go with it.
+moved {
+  from = aws_elasticache_cluster.n8n
+  to   = aws_elasticache_cluster.n8n[0]
+}

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -992,6 +992,30 @@ run "redis_transit_encryption_on_swaps_to_replication_group" {
   }
 }
 
+# ElastiCache shares one identifier namespace between cache clusters and
+# replication groups. The two resources here are independent, so Terraform will
+# happily create the replication group while the old cluster still exists — and
+# with a shared identifier AWS rejects it:
+#
+#   InvalidParameterValue: Cannot have a cluster and replication group with
+#   same identifier.
+#
+# The old cache is already destroyed by that point, so the caller is left with
+# no queue backend and a failed apply. Found on a live cluster, and cheap enough
+# to pin here that it should never be found that way twice.
+run "redis_identifiers_must_not_collide_across_paths" {
+  command = plan
+
+  variables {
+    redis_transit_encryption_enabled = true
+  }
+
+  assert {
+    condition     = aws_elasticache_replication_group.n8n[0].replication_group_id == "n8n-cluster-redis-tls"
+    error_message = "The replication group must not reuse the cache cluster's identifier — ElastiCache rejects the create, after the old cache has already been destroyed."
+  }
+}
+
 # The AUTH token charset is not a free choice: ElastiCache rejects anything
 # outside ! & # $ ^ < > - at create time, and the failure surfaces as an opaque
 # InvalidParameterValue from AWS well into the apply. Asserting the generator's

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -889,12 +889,12 @@ run "redis_private_and_sized" {
   command = plan
 
   assert {
-    condition     = aws_elasticache_cluster.n8n.engine == "redis"
+    condition     = aws_elasticache_cluster.n8n[0].engine == "redis"
     error_message = "ElastiCache engine should be redis"
   }
 
   assert {
-    condition     = aws_elasticache_cluster.n8n.node_type == "cache.t3.medium"
+    condition     = aws_elasticache_cluster.n8n[0].node_type == "cache.t3.medium"
     error_message = "redis_node_type should default to cache.t3.medium"
   }
 
@@ -911,6 +911,109 @@ run "redis_private_and_sized" {
   assert {
     condition     = one(aws_security_group.redis.ingress).protocol == "tcp"
     error_message = "Redis SG should restrict ingress to TCP"
+  }
+}
+
+# ── Redis transit encryption + AUTH (opt-in) ──────────────────────────────────
+# The default must stay the network-trust posture, and the opt-in path swaps the
+# cache resource wholesale: auth_token exists only on
+# aws_elasticache_replication_group, so aws_elasticache_cluster cannot carry it.
+# These two runs pin both halves of that swap, in both directions.
+
+run "redis_transit_encryption_defaults_off" {
+  command = plan
+
+  assert {
+    condition     = var.redis_transit_encryption_enabled == false
+    error_message = "redis_transit_encryption_enabled must default to false — the network-trust posture is the accepted as-built behaviour and enabling it replaces the cache."
+  }
+
+  assert {
+    condition     = length(aws_elasticache_cluster.n8n) == 1
+    error_message = "The default path must keep the aws_elasticache_cluster resource it has always used, so existing deployments see no replacement."
+  }
+
+  assert {
+    condition     = length(aws_elasticache_replication_group.n8n) == 0
+    error_message = "No replication group should exist on the default path"
+  }
+
+  assert {
+    condition     = length(random_password.redis_auth_token) == 0
+    error_message = "No AUTH token should be generated on the default path — an unconditional random_password would put `1 to add` in the plan of every caller who never opted in."
+  }
+
+  assert {
+    condition     = length(kubernetes_secret.n8n_redis) == 0
+    error_message = "No Redis secret should exist when there is no AUTH token to hold"
+  }
+}
+
+run "redis_transit_encryption_on_swaps_to_replication_group" {
+  command = plan
+
+  variables {
+    redis_transit_encryption_enabled = true
+  }
+
+  assert {
+    condition     = length(aws_elasticache_cluster.n8n) == 0
+    error_message = "The cluster resource cannot carry an auth_token, so the opt-in path must not create one"
+  }
+
+  assert {
+    condition     = length(aws_elasticache_replication_group.n8n) == 1
+    error_message = "The opt-in path must create the replication group, the only ElastiCache resource that accepts an auth_token"
+  }
+
+  assert {
+    condition     = aws_elasticache_replication_group.n8n[0].transit_encryption_enabled == true
+    error_message = "transit_encryption_enabled must be true — AWS rejects an AUTH token without it"
+  }
+
+  assert {
+    condition     = aws_elasticache_replication_group.n8n[0].num_cache_clusters == 1
+    error_message = "The opt-in path must stay single-node, matching the cluster path. This variable buys encryption, not a second node and a doubled bill."
+  }
+
+  assert {
+    condition     = aws_elasticache_replication_group.n8n[0].node_type == "cache.t3.medium"
+    error_message = "redis_node_type should reach the replication group too, not just the cluster"
+  }
+
+  assert {
+    condition     = length(random_password.redis_auth_token) == 1
+    error_message = "An AUTH token must be generated on the opt-in path"
+  }
+
+  assert {
+    condition     = length(kubernetes_secret.n8n_redis) == 1
+    error_message = "The AUTH token must be published as a Kubernetes secret for the chart to mount as QUEUE_BULL_REDIS_PASSWORD"
+  }
+}
+
+# The AUTH token charset is not a free choice: ElastiCache rejects anything
+# outside ! & # $ ^ < > - at create time, and the failure surfaces as an opaque
+# InvalidParameterValue from AWS well into the apply. Asserting the generator's
+# inputs catches a careless edit at plan time instead.
+run "redis_auth_token_respects_elasticache_charset" {
+  command = plan
+
+  variables {
+    redis_transit_encryption_enabled = true
+  }
+
+  assert {
+    condition     = random_password.redis_auth_token[0].override_special == "!&#$^<>-"
+    error_message = "AUTH token special characters must be limited to the set ElastiCache permits (! & # $ ^ < > -)"
+  }
+
+  assert {
+    condition = (
+      random_password.redis_auth_token[0].length >= 16 &&
+      random_password.redis_auth_token[0].length <= 128
+    )
+    error_message = "ElastiCache AUTH tokens must be 16-128 characters"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -626,6 +626,12 @@ variable "redis_node_type" {
   }
 }
 
+variable "redis_transit_encryption_enabled" {
+  description = "Encrypt the n8n queue backend in transit and require an AUTH token on it. Defaults to false, which is the module's deliberate network-trust posture: Redis sits in private subnets behind a security group that admits only VPC traffic, so isolation is by network boundary rather than by credentials. Set true to add TLS plus a generated AUTH token on top of that boundary — worth doing when queue payloads (workflow execution data) crossing the VPC in cleartext, or an unauthenticated Redis after a network-boundary breach, are risks you need closed. CHANGING THIS ON AN EXISTING DEPLOYMENT REPLACES REDIS: AWS exposes the AUTH token only on aws_elasticache_replication_group, so the opt-in path uses that resource while the default path keeps aws_elasticache_cluster. Flipping the value destroys one and creates the other, which drops every job queued at that moment — drain workers and pick a maintenance window. KNOWN LIMITATION: KEDA's worker autoscaler has no TLS or credentials on its Redis trigger yet, so while this is true, queue-depth autoscaling stops responding to backlog and workers hold a static count between n8n_worker_keda_min_replicas and n8n_worker_keda_max_replicas. Tracked in https://github.com/n8n-io/terraform-aws-n8n/issues/66."
+  type        = bool
+  default     = false
+}
+
 variable "n8n_task_runner_request_timeout" {
   description = "Seconds n8n waits for a task runner to accept a Code node task. Wired to the N8N_RUNNERS_TASK_REQUEST_TIMEOUT env var on the main pod. Increase if Code nodes fail with 'task request timed out' under high concurrency (many parallel Code nodes competing for the single runner sidecar)."
   type        = number


### PR DESCRIPTION
Closes #41.

Adds an opt-in, default-off `redis_transit_encryption_enabled` that puts the ElastiCache queue backend behind TLS and an AUTH token. The default preserves the module's network-trust posture, so callers who leave it alone see no plan diff.

## Why the opt-in path uses a different AWS resource

`auth_token` does not exist on `aws_elasticache_cluster`. AWS exposes it only on `aws_elasticache_replication_group`, and further requires transit encryption to be enabled before AUTH can be used at all. The module therefore carries both resources, count-gated and mutually exclusive:

| `redis_transit_encryption_enabled` | Resource |
| --- | --- |
| `false` (default) | `aws_elasticache_cluster.n8n[0]` |
| `true` | `aws_elasticache_replication_group.n8n[0]` |

Migrating everyone to the replication group would have read more simply, but it replaces the cache for every existing deployment. Both are single-node with the same `redis_node_type`, so enabling the flag changes neither topology nor cost. Consumers read `local.redis_host` rather than either resource, so the Helm values, KEDA trigger addresses and the `redis_endpoint` output cannot drift apart.

A `moved` block absorbs the `count` added to `aws_elasticache_cluster.n8n`. Without it, the new address reads as a different resource and **every consumer replaces their Redis on upgrade**, whether or not they set the new variable.

## Live verification

Applied against a real cluster (`iss41dev`, us-east-1, default sizing). Full log in the deploy harness; summary:

| Scenario | Result |
| --- | --- |
| S1 — baseline on `main` | Pass. 75 resources, six pods Running |
| S2 — upgrade to this branch, flag off | Pass. `Plan: 0 to add, 0 to change, 0 to destroy` |
| S3 — enable flag | **Failed. Found a real defect** (below) |
| S3b — enable flag, after fix | Pass. TLS + AUTH working end to end |
| S4 — KEDA limitation | Confirmed, mechanism corrected |

### S2 is the backward-compatibility proof

```
# module.n8n.aws_elasticache_cluster.n8n has moved to module.n8n.aws_elasticache_cluster.n8n[0]
Plan: 0 to add, 0 to change, 0 to destroy.
```

This is the claim a plan-time test structurally cannot make: a fresh plan writes `[0]` from the start and passes whether or not the `moved` block exists. It had to be measured against real prior state.

### The defect the live run caught

```
Error: creating ElastiCache Replication Group (iss41dev-redis):
InvalidParameterValue: Cannot have a cluster and replication group with same identifier.
```

ElastiCache shares one identifier namespace across cache clusters and replication groups. The two Terraform resources have no dependency edge, so Terraform created the replacement while the old cache still existed. It had **already destroyed the cluster** by then, leaving the deployment with no queue backend and needing a second apply to recover.

The docs at that point promised "flipping the flag replaces Redis and loses queued jobs." The truth was "destroys Redis, fails the apply, leaves nothing." Materially different advice. Fixed by naming the replication group `<cluster_name>-redis-tls`, which removes the hazard in both directions, and pinned by a regression test.

Worth noting: S2 and all 104 plan-time tests passed while this was broken.

### Proof the feature actually works

Protocol-level, from inside the cluster:

| Probe | Result |
| --- | --- |
| TLS + token | `PONG` |
| TLS + token, `KEYS bull:*` | `bull:jobs:stalled-check` |
| TLS, no token | `NOAUTH Authentication required.` |
| Plaintext, no TLS | no response |

The last two are the security claim itself: unauthenticated and unencrypted access are both refused.

End to end, with `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true` forcing the job across the queue:

```
POST /rest/workflows/<id>/run  → 200, executionId 1
GET  /rest/executions/1        → status=success, output contains "redis-tls-auth-ok"

worker log:
  Worker started execution 1 (job 1)
  Worker finished execution 1 (job 1)
```

### A risk that did not materialise

n8n's config recommends `QUEUE_BULL_REDIS_DNS_LOOKUP_STRATEGY=NONE` for ElastiCache with TLS, warning of hostname/IP cert mismatches. It was deliberately not set pre-emptively so this run would produce evidence rather than a guess. No cert errors appeared, consistent with that caveat applying to cluster-mode ElastiCache resolving nodes to IPs, whereas this is cluster-mode-disabled connecting by hostname. Left unset.

## Known limitation shipped with this (#66)

KEDA's worker autoscaler cannot reach an encrypted Redis. Observed:

```
ERROR scale_handler error resolving auth params
  {"name": "n8n-worker", "error": "connection to redis failed: i/o timeout"}

keda-hpa-n8n-worker   TARGETS: <unknown>/5 (avg), <unknown>/5 (avg)   1   10   2
```

An i/o timeout, not `NOAUTH` — KEDA opens a plaintext connection to a TLS-only endpoint and hangs, never reaching authentication. So **TLS is the first-order fix for #66**, not auth; #66 has been updated with this. n8n itself is unaffected — the autoscaler is the only casualty, which is what makes it easy to miss.

Documented in the variable description, README, and CHANGELOG. Sub-issue #66 tracks the fix.

## Checks

`fmt` clean, `validate` Success, `tflint` 0 findings, `terraform-docs` in sync, **105 tests pass**, `checkov` identical to `main` (171/28/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)