### PR TITLE
fix: size default HPA maxima to schedulable node capacity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,28 @@ file. Use `command = plan` unless you specifically need apply semantics.
   intended to order a caller's resources, return the **resource attribute**
   rather than the variable, and treat "did the graph actually serialise these"
   as a question only a live apply answers.
+- **A `run` block cannot express "argument passed as `null`".** In a `variables`
+  block, `x = null` means *unset*: the variable takes its default and no error is
+  raised. A real caller writing `x = null` in a `module` block is different:
+  null **propagates into the module** rather than falling back to the default,
+  unless the variable declares `nullable = false`. Measured on 1.9.8, one module
+  with `default = 6` invoked three ways: no argument sees `6`; `n = null` on a
+  nullable variable sees `null`; `n = null` on a `nullable = false` variable sees
+  `6`, silently, with no error. Only the middle case can break anything, and it
+  is the only one a `run` block cannot reproduce.
+
+  This is not academic. It is how the `nullable = false` gap on the autoscaling
+  inputs was found (see `scaling.tf`): Terraform evaluates a `check` block's
+  `error_message` alongside its condition rather than lazily on failure, so a
+  propagated null reached the message's interpolations and aborted the plan with
+  `Invalid template interpolation value`, from a block whose entire purpose is
+  to warn *without* failing. `expect_failures` cannot assert it; the attempt
+  fails with "Missing expected failure".
+
+  So: for any input with a default where null is not meaningful, declare
+  `nullable = false` rather than trusting a test to catch it. Null-handling is a
+  question only a real `module` block answers, which means a live plan against a
+  caller configuration rather than the mocked suite.
 
 #### `check` conditions must short-circuit on Terraform 1.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,6 +398,17 @@ this project adheres to the stability contract in
   editor and REST API users, not a tier's executions/day. Resolves
   [#51](https://github.com/n8n-io/terraform-aws-n8n/issues/51).
 
+- `node_instance_type`, `node_max`, `n8n_task_runners_enabled`, and the six
+  autoscaler floor and ceiling inputs now declare `nullable = false`. A caller
+  passing an explicit `null` for one of these previously propagated it into
+  the module instead of falling back to the default, and once the capacity
+  check existed that null aborted the plan from inside the check's
+  interpolations (see the AGENTS.md note on null and `nullable = false`).
+  With `nullable = false`, Terraform substitutes the declared default at the
+  variable boundary. Only callers writing a literal `null` for one of these
+  nine inputs observe any change: they now get the default silently rather
+  than an error partway through the plan.
+
 - `aws_route53_record.cert_validation` keys its `for_each` off
   `local.acm_domain_names` instead of the certificate's computed
   `domain_validation_options`, and selects each record's values by matching

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,51 @@ this project adheres to the stability contract in
   from README.md and docs/troubleshooting.md, and the split-ingress example's
   `mcp_single_replica` workaround variable was removed with them.
 
+- Every `helm upgrade` scaled the main, worker and webhook deployments down to 2
+  replicas before their autoscalers climbed back. The chart renders
+  `spec.replicas` unconditionally on all three deployments, from
+  `multiMain.replicas`, `queueMode.workerReplicaCount` and
+  `webhookProcessor.replicaCount`, with no regard for whether an HPA or a KEDA
+  ScaledObject also owns the field. The module passed a constant `2` for all
+  three, so Helm and the autoscaler disagreed on every apply.
+
+  It reset any scale-up, not only a configured floor: a deployment the HPA had
+  taken to 8 under load went back to 2 and had to climb again. It cost most where
+  the floor was highest, since `examples/large` runs a webhook floor of 30 and a
+  worker floor of 20, both of which collapsed to 2 on each apply and then had to
+  be re-scaled while traffic was already arriving. Same class of defect as
+  [#51](https://github.com/n8n-io/terraform-aws-n8n/issues/51): pod count driven
+  by two sources that disagree.
+
+  All three are now wired to their autoscaler's floor
+  (`n8n_main_hpa_min_replicas`, `n8n_worker_keda_min_replicas`,
+  `n8n_webhook_hpa_min_replicas`), making Helm's write a no-op. Deployments on
+  the default floors see no change, since those already matched the constant.
+
+  Verified on a live cluster rather than by inspection, because no plan-time test
+  can observe a `helm upgrade`. A 3-node cluster was applied from the previous
+  version with a webhook floor of 5 and a worker floor of 3, then given one
+  unrelated config change to trigger an upgrade. Sampling `spec.replicas` every
+  two seconds through it:
+
+  ```
+     5 samples  webhook=5 worker=3   <- steady state at the configured floors
+     2 samples  webhook=2 worker=2   <- Helm re-asserts spec.replicas=2
+    41 samples  webhook=5 worker=3   <- HPA and KEDA climb back
+  ```
+
+  Webhook capacity dropped 60% and worker 33% mid-upgrade, and `helm get manifest`
+  confirmed the release's stored desired state read `replicas: 2` for all three
+  while the cluster ran 5 and 3. Repointing at this version planned `Plan: 0 to
+  add, 1 to change, 0 to destroy`, an in-place `helm_release` update with no
+  replacement of the ALB, RDS instance, KMS key or any PVC, and moved the stored
+  manifest to 5 and 3. A second, pod-churning upgrade of the same duration as the
+  one that collapsed (1m45s) held every one of 48 samples steady.
+
+  A no-op re-apply does **not** show the defect, since Terraform only runs
+  `helm upgrade` when the values change. It takes a real config change or version
+  bump, which is also when it surfaces in practice.
+
 - `db_allowed_cidr_blocks` is now de-duplicated against the always-allowed VPC
   CIDR. Passing the VPC CIDR explicitly, or repeating an entry, previously
   produced a security group rule with the same permission twice, which AWS
@@ -65,6 +110,54 @@ this project adheres to the stability contract in
   API before fixing.
 
 ### Added
+
+- Plan-time warning when the autoscaler ceilings, the per-pod CPU requests, and
+  the node group are out of step. `scaling.tf` models the CPU arithmetic and the
+  `autoscaling_maxima_fit_node_group_capacity` check reports the numbers when the
+  three pod families at their maxima cannot fit in `node_max` ×
+  `node_instance_type`. The demand side sums the main, worker and webhook
+  ceilings, counting task runner sidecars on main and worker pods only, since the
+  chart adds no sidecar to webhook processors. The supply side discounts each
+  node's vCPU by the EKS kubelet reservation, the `aws-node` and `kube-proxy`
+  DaemonSets, and this module's cluster add-ons.
+
+  A `check` block, so it never fails a plan: the model is an approximation, and
+  staging higher ceilings before raising `node_max` is legitimate. vCPU is
+  derived from the instance size rather than read from
+  `data.aws_ec2_instance_type`, because a `check` whose condition is unknown at
+  plan is a hard error rather than a warning and a data source read is exactly
+  what Terraform can defer to apply. An advisory hint must not be able to break
+  a plan. Verified against `ec2:DescribeInstanceTypes` across all 1,150 types
+  offered in eu-west-1: exact for 995, silent for the 104 bare-metal sizes, and
+  biased toward silence rather than false alarms on the rest. New section in
+  README.md, "Sizing autoscaling against node capacity", documents the
+  arithmetic.
+
+  The supply-side constants are the requests these workloads declare on a cluster
+  this module builds, not the figures the upstream charts document: 180m per node
+  for the `aws-node`, `kube-proxy` and `ebs-csi-node` DaemonSets, and 720m once
+  for CoreDNS, metrics-server, KEDA and `ebs-csi-controller`.
+  `ebs-csi-node-windows` is excluded because it reports
+  `desiredNumberScheduled = 0` on a Linux node group. The EKS kubelet reservation
+  is modelled from the AMI's own curve, with t3.xlarge reporting 3,920m
+  allocatable.
+
+  Checked against the real scheduler rather than by inspection, by driving a
+  webhook HPA past capacity on a 3-node cluster. The model predicted 10,500m
+  available; the scheduler placed 10,200m and left 21 pods `Pending` with `0/3
+  nodes are available: 3 Insufficient cpu` while the Cluster Autoscaler sat at
+  `node_max`, which is the failure #51 reports. The 300m residue is bin-packing
+  fragmentation, which no request-based model can represent, so read the warning
+  as a bound rather than a prediction.
+
+- Validation rejecting an autoscaler floor above its own ceiling, for all three
+  pod families. Kubernetes rejects an HPA whose `minReplicas` exceeds its
+  `maxReplicas` and KEDA does the same for a ScaledObject, so this previously
+  failed partway through an apply. Lowering the two default ceilings above makes
+  the combination reachable for a caller who changes nothing, which is why the
+  check is at the variable boundary: the error names both inputs and their values
+  before anything is sent to the cluster. A floor equal to its ceiling stays
+  valid, since that is how you pin a fixed-size deployment.
 
 - `n8n_license_detach_floating_on_shutdown` input (default `false`) maps to
   `N8N_LICENSE_DETACH_FLOATING_ON_SHUTDOWN`, overriding n8n's own upstream
@@ -235,6 +328,59 @@ this project adheres to the stability contract in
   every existing deployment would destroy and recreate its alias record.
 
 ### Changed
+
+- **Default HPA maxima now fit the default node group.**
+  `n8n_main_hpa_max_replicas` drops from `20` to `6` and
+  `n8n_webhook_hpa_max_replicas` from `50` to `8`. The old defaults were
+  unschedulable by construction: 20 main pods plus their task runner sidecars
+  request 24,000m CPU on their own, more than the entire default node group
+  (`node_max = 6` × t3.xlarge = 24 vCPU) can ever provide, before the worker and
+  webhook ceilings are counted at all.
+
+  The failure mode is not a plan error but a slow one. During a rollout with
+  elevated CPU the HPAs scale toward their maxima, the Cluster Autoscaler hits
+  `node_max`, and the pods that do not fit sit `Pending` with `Insufficient cpu`
+  (15 of them in the deployment that surfaced this). The surging ReplicaSet then
+  competes for the same exhausted CPU, which stretches out the rollout until the
+  HPAs are capped by hand.
+
+  At the new defaults the three pod families request 16,600m against roughly
+  21,720m schedulable, leaving headroom for a rolling-update surge.
+
+  Upgrade note: an explicit ceiling is untouched. Both HPAs update in place, with
+  no resource replacement, but a cluster currently running more than 6 main or 8
+  webhook pods will be scaled back to the new ceiling on the next apply. If you
+  rely on the old ceilings, set them explicitly and size `node_max` /
+  `node_instance_type` to match.
+
+  One case fails the plan outright: an explicit floor above the new ceiling, which
+  a caller could reach without changing anything. `n8n_main_hpa_min_replicas = 8`
+  or `n8n_webhook_hpa_min_replicas = 10` was valid against the old ceilings of 20
+  and 50, and against the new ones is not:
+
+  ```
+  Error: Invalid value for variable
+    │ var.n8n_main_hpa_max_replicas is 6
+    │ var.n8n_main_hpa_min_replicas is 8
+  n8n_main_hpa_min_replicas must not exceed n8n_main_hpa_max_replicas
+  ```
+
+  Raise the matching ceiling explicitly, and `node_max` /
+  `node_instance_type` with it. The new validation below is what makes this a
+  plan-time error naming both inputs, rather than a Kubernetes rejection partway
+  through `helm upgrade`.
+
+  `examples/medium` and `examples/large` now pin the main pod range explicitly
+  (3/24 and 6/60) rather than inheriting it, so it is tied to each tier's node
+  group instead of to the starter default, and both tiers' sizing tables gained a
+  main-pod row. The raised floors match the warm-floor approach both tiers already
+  take for webhook and worker pods: n8n pods take tens of seconds to boot, so a
+  floor of 2 puts an editor or API burst behind pod startup. Main pods carry
+  neither production webhooks (the module sets
+  `disableProductionWebhooksOnMainProcess`) nor manual executions (the chart sets
+  `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS`), so a main ceiling tracks concurrent
+  editor and REST API users, not a tier's executions/day. Resolves
+  [#51](https://github.com/n8n-io/terraform-aws-n8n/issues/51).
 
 - `aws_route53_record.cert_validation` keys its `for_each` off
   `local.acm_domain_names` instead of the certificate's computed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,21 @@ this project adheres to the stability contract in
 
   All three are now wired to their autoscaler's floor
   (`n8n_main_hpa_min_replicas`, `n8n_worker_keda_min_replicas`,
-  `n8n_webhook_hpa_min_replicas`), making Helm's write a no-op. Deployments on
-  the default floors see no change, since those already matched the constant.
+  `n8n_webhook_hpa_min_replicas`), so the manifest agrees with the autoscaler on
+  where the deployment rests. Helm's write is a no-op while the deployment sits
+  at its floor.
+
+  This bounds the drop rather than eliminating it, and the distinction matters if
+  you upgrade under load. A deployment the autoscaler has taken above its floor
+  is still written back down to the floor, and still has to climb again: for
+  `examples/large` that is a webhook deployment at 80 dropping to 30 instead of
+  to 2. Bounding it at the floor is the most a caller of this chart can do, since
+  the field is rendered unconditionally and no value omits it, and reading the
+  live replica count back into the plan would make every plan depend on current
+  cluster state. Eliminating it needs the chart to guard `spec.replicas` on
+  whether an autoscaler owns the deployment, which is an upstream change.
+  Deployments resting on the default floors see no change, since those already
+  matched the constant.
 
   Verified on a live cluster rather than by inspection, because no plan-time test
   can observe a `helm upgrade`. A 3-node cluster was applied from the previous
@@ -96,7 +109,9 @@ this project adheres to the stability contract in
   add, 1 to change, 0 to destroy`, an in-place `helm_release` update with no
   replacement of the ALB, RDS instance, KMS key or any PVC, and moved the stored
   manifest to 5 and 3. A second, pod-churning upgrade of the same duration as the
-  one that collapsed (1m45s) held every one of 48 samples steady.
+  one that collapsed (1m45s) held every one of 48 samples steady. Both runs had
+  the deployments resting at their floors, which is the case the fix closes; the
+  above-the-floor case described above was not exercised on the cluster.
 
   A no-op re-apply does **not** show the defect, since Terraform only runs
   `helm upgrade` when the values change. It takes a real config change or version
@@ -128,8 +143,9 @@ this project adheres to the stability contract in
   plan is a hard error rather than a warning and a data source read is exactly
   what Terraform can defer to apply. An advisory hint must not be able to break
   a plan. Verified against `ec2:DescribeInstanceTypes` across all 1,150 types
-  offered in eu-west-1: exact for 995, silent for the 104 bare-metal sizes, and
-  biased toward silence rather than false alarms on the rest. New section in
+  offered in eu-west-1: exact for 995, silent for the 104 bare-metal sizes,
+  over-counted on 48 (which costs a warning rather than raising a false one), and
+  under-counted on 3 legacy types that can warn a hair early. New section in
   README.md, "Sizing autoscaling against node capacity", documents the
   arithmetic.
 

--- a/README.md
+++ b/README.md
@@ -465,6 +465,105 @@ Terraform state and the pod environment in plaintext — restrict access
 accordingly. Setting `n8n_log_streaming_managed_by_env` back to `false`
 keeps the last applied destinations but restores UI write access.
 
+## Sizing autoscaling against node capacity
+
+Three groups of inputs have to be sized together, and nothing in Kubernetes
+couples them for you:
+
+| Group | Inputs |
+| --- | --- |
+| Autoscaler ceilings | `n8n_main_hpa_max_replicas`, `n8n_webhook_hpa_max_replicas`, `n8n_worker_keda_max_replicas` |
+| Per-pod CPU requests | `n8n_main_cpu_request`, `n8n_webhook_cpu_request`, `n8n_worker_cpu_request`, `n8n_task_runner_cpu_request` |
+| Node group | `node_instance_type`, `node_max` |
+
+Set a ceiling above what the node group can hold and the autoscalers will
+still scale toward it. The pods that do not fit sit `Pending` with
+`Insufficient cpu` while the Cluster Autoscaler is already at `node_max` with
+nothing left to add. Because a surging ReplicaSet competes for the same
+exhausted CPU, this also stretches out rollouts, which is how the problem
+usually surfaces ([#51](https://github.com/n8n-io/terraform-aws-n8n/issues/51)).
+For the symptom side, see
+[docs/troubleshooting.md](docs/troubleshooting.md#pods-stay-pending-with-insufficient-cpu-and-the-node-group-never-grows).
+
+The module warns at plan time when the arithmetic does not work out. Raising the
+main ceiling to 20 and the webhook ceiling to 50 against the default node group,
+for instance, produces:
+
+```
+│ Warning: Check block assertion failed
+│
+│ Autoscaler maxima exceed the CPU the node group can ever schedule. At their
+│ ceilings the n8n pods request 46000m CPU (main 20 × 1200m, worker 10 × 700m,
+│ webhook 50 × 300m), but 6 × t3.xlarge leaves only about 21720m for them
+│ (4 vCPU per node, less kubelet reservations, the aws-node and kube-proxy
+│ DaemonSets, and this module's cluster add-ons). The autoscalers will still
+│ scale toward those maxima, leaving pods Pending with "Insufficient cpu" once
+│ the Cluster Autoscaler reaches node_max. Either lower the maxima, lower the
+│ CPU requests, or raise node_max / node_instance_type.
+```
+
+It is a `check` block, so it never fails a plan or an apply. Staging higher
+ceilings before you raise `node_max` is a legitimate thing to do, and the model
+is an approximation of a real scheduler.
+
+### The arithmetic
+
+**Demand**, when every autoscaler happens to sit at its ceiling at once:
+
+```
+main_max    × (main_cpu_request    + task_runner_cpu_request)
+worker_max  × (worker_cpu_request  + task_runner_cpu_request)
+webhook_max ×  webhook_cpu_request
+```
+
+Task runner sidecars ride on main and worker pods only, so webhook processors
+carry no sidecar cost. Workers are on KEDA rather than an HPA, but they compete
+for the same nodes and count against the same budget.
+
+**Supply** is less than `node_max` × the instance's vCPU count:
+
+- EKS reserves CPU for kubelet and the runtime on a tiered curve: 6% of the
+  first vCPU, 1% of the second, 0.5% of the third and fourth, 0.25% of each
+  beyond. A t3.xlarge reports 3,920m allocatable, not 4,000m.
+- DaemonSets run on every node and claim their requests first: `aws-node` 50m
+  (two containers), `kube-proxy` 100m, and `ebs-csi-node` 30m, so 180m per node.
+- Cluster-wide singletons come off the total once: CoreDNS 200m, metrics-server
+  100m, KEDA's three components 300m, and `ebs-csi-controller` 120m, so 720m.
+
+At the defaults that is 6 × t3.xlarge → about **21,720m** for n8n, against
+**16,600m** requested at the default ceilings. The remainder is deliberate
+headroom for the surge during a rolling update.
+
+### Floors are also the deployment's replica count
+
+The three floors (`n8n_main_hpa_min_replicas`, `n8n_webhook_hpa_min_replicas`,
+`n8n_worker_keda_min_replicas`) do double duty: the module passes each one to the
+chart as that deployment's `spec.replicas`. The chart renders `spec.replicas`
+unconditionally, whether or not an HPA or a KEDA ScaledObject also owns the
+field, so a value below the autoscaler's floor would make every `helm upgrade`
+scale down and then wait for the autoscaler to climb back, which is precisely
+when you want the warm capacity.
+
+Raise a floor when startup latency matters more than idle cost. n8n pods take
+tens of seconds to boot, so a burst that arrives before the autoscaler reacts
+queues behind pod startup. `examples/medium` and `examples/large` raise all three
+floors for that reason.
+
+### Raising the ceilings
+
+Raise `node_max` or `node_instance_type` in the same change. As a rule of
+thumb at the default CPU requests, each t3.xlarge node carries about three
+main pods, five workers, or twelve webhook processors. `examples/medium` and
+`examples/large` show ceilings pinned well above the module defaults against
+node groups sized to match.
+
+The check derives vCPU from the instance size rather than calling the EC2 API,
+so that an undeterminable value can never turn an advisory warning into a failed
+plan. It is exact for 995 of the 1,150 instance types EC2 currently offers in
+eu-west-1. Bare-metal sizes silence the check entirely, as does a CPU request in
+a form the module cannot parse; the remaining deviations are legacy and 1 vCPU
+families that make the check quieter, not noisier.
+
 ## Reference
 
 <!-- The block below is auto-generated by terraform-docs. Run `terraform-docs markdown table --output-file README.md --output-mode inject .` to refresh it. -->
@@ -603,8 +702,8 @@ No modules.
 | <a name="input_n8n_main_cpu_limit"></a> [n8n\_main\_cpu\_limit](#input\_n8n\_main\_cpu\_limit) | CPU limit for n8n main pods (e.g. 2000m, 1000m) | `string` | `"2000m"` | no |
 | <a name="input_n8n_main_cpu_request"></a> [n8n\_main\_cpu\_request](#input\_n8n\_main\_cpu\_request) | CPU request for n8n main pods (e.g. 1000m, 500m) | `string` | `"1000m"` | no |
 | <a name="input_n8n_main_hpa_cpu_threshold"></a> [n8n\_main\_hpa\_cpu\_threshold](#input\_n8n\_main\_hpa\_cpu\_threshold) | Target average CPU utilization (%) that triggers scaling of n8n main pods. | `number` | `60` | no |
-| <a name="input_n8n_main_hpa_max_replicas"></a> [n8n\_main\_hpa\_max\_replicas](#input\_n8n\_main\_hpa\_max\_replicas) | Maximum replicas for n8n main pods. HPA will not scale above this. | `number` | `20` | no |
-| <a name="input_n8n_main_hpa_min_replicas"></a> [n8n\_main\_hpa\_min\_replicas](#input\_n8n\_main\_hpa\_min\_replicas) | Minimum replicas for n8n main pods. HPA will not scale below this. | `number` | `2` | no |
+| <a name="input_n8n_main_hpa_max_replicas"></a> [n8n\_main\_hpa\_max\_replicas](#input\_n8n\_main\_hpa\_max\_replicas) | Maximum replicas for n8n main pods. HPA will not scale above this. The default of 6 is sized to the default node group (node\_max × node\_instance\_type): at the default CPU requests, 6 main pods plus their task runner sidecars, the worker ceiling, and the webhook ceiling all fit in what 6 t3.xlarge nodes can schedule. Raise this together with node\_max or node\_instance\_type. An HPA ceiling the node group cannot hold leaves pods Pending with "Insufficient cpu" once the Cluster Autoscaler reaches node\_max, which also slows rollouts. The module warns at plan time when the three groups are out of step; see README.md → "Sizing autoscaling against node capacity". | `number` | `6` | no |
+| <a name="input_n8n_main_hpa_min_replicas"></a> [n8n\_main\_hpa\_min\_replicas](#input\_n8n\_main\_hpa\_min\_replicas) | Minimum replicas for n8n main pods. HPA will not scale below this. Also becomes the deployment's own replica count: the Helm chart renders spec.replicas unconditionally, so leaving it below the autoscaler floor would make every helm upgrade scale down and then wait for the autoscaler to climb back. Keep at 2 or more for availability: mains serve the editor and REST API, and the module's PodDisruptionBudget only guarantees one during a node drain. | `number` | `2` | no |
 | <a name="input_n8n_main_memory_limit"></a> [n8n\_main\_memory\_limit](#input\_n8n\_main\_memory\_limit) | Memory limit for n8n main pods (e.g. 4Gi, 2Gi) | `string` | `"4Gi"` | no |
 | <a name="input_n8n_main_memory_request"></a> [n8n\_main\_memory\_request](#input\_n8n\_main\_memory\_request) | Memory request for n8n main pods (e.g. 2Gi, 1Gi) | `string` | `"2Gi"` | no |
 | <a name="input_n8n_metrics_enabled"></a> [n8n\_metrics\_enabled](#input\_n8n\_metrics\_enabled) | Enable n8n's built-in Prometheus metrics endpoint. When true, the module appends N8N\_METRICS=true to the n8n Helm release's config.extraEnv, which the chart applies to every n8n container (main, worker, webhook processor). n8n exposes /metrics on its existing HTTP port (5678) — the same port and service the chart already publishes for the UI/API. The n8n Helm chart at the currently pinned version (see n8n\_chart\_version) exposes no top-level metrics / serviceMonitor block of its own, so this toggle is intentionally env-var-only. Scrape configuration (Prometheus scrape annotations or a ServiceMonitor CR) is left to the caller's monitoring stack — in practice the main pod's Service is the meaningful scrape target. Defaults to false; when false the env var is omitted entirely so n8n's own defaults apply. | `bool` | `false` | no |
@@ -635,8 +734,8 @@ No modules.
 | <a name="input_n8n_webhook_cpu_limit"></a> [n8n\_webhook\_cpu\_limit](#input\_n8n\_webhook\_cpu\_limit) | CPU limit for n8n webhook processor pods (e.g. 800m, 1000m) | `string` | `"800m"` | no |
 | <a name="input_n8n_webhook_cpu_request"></a> [n8n\_webhook\_cpu\_request](#input\_n8n\_webhook\_cpu\_request) | CPU request for n8n webhook processor pods (e.g. 300m, 500m) | `string` | `"300m"` | no |
 | <a name="input_n8n_webhook_hpa_cpu_threshold"></a> [n8n\_webhook\_hpa\_cpu\_threshold](#input\_n8n\_webhook\_hpa\_cpu\_threshold) | Target average CPU utilization (%) that triggers scaling of n8n webhook pods. | `number` | `65` | no |
-| <a name="input_n8n_webhook_hpa_max_replicas"></a> [n8n\_webhook\_hpa\_max\_replicas](#input\_n8n\_webhook\_hpa\_max\_replicas) | Maximum replicas for n8n webhook processor pods. HPA will not scale above this. | `number` | `50` | no |
-| <a name="input_n8n_webhook_hpa_min_replicas"></a> [n8n\_webhook\_hpa\_min\_replicas](#input\_n8n\_webhook\_hpa\_min\_replicas) | Minimum replicas for n8n webhook processor pods. HPA will not scale below this. | `number` | `2` | no |
+| <a name="input_n8n_webhook_hpa_max_replicas"></a> [n8n\_webhook\_hpa\_max\_replicas](#input\_n8n\_webhook\_hpa\_max\_replicas) | Maximum replicas for n8n webhook processor pods. HPA will not scale above this. The default of 8 is sized to the default node group (node\_max × node\_instance\_type), alongside the main and worker ceilings. Webhook processors are the cheapest pod family to scale (no task runner sidecar, 300m by default), so this is usually the first ceiling to raise once node\_max goes up. See n8n\_main\_hpa\_max\_replicas and README.md → "Sizing autoscaling against node capacity". | `number` | `8` | no |
+| <a name="input_n8n_webhook_hpa_min_replicas"></a> [n8n\_webhook\_hpa\_min\_replicas](#input\_n8n\_webhook\_hpa\_min\_replicas) | Minimum replicas for n8n webhook processor pods. HPA will not scale below this. Also becomes the deployment's own replica count: the Helm chart renders spec.replicas unconditionally, so leaving it below the autoscaler floor would make every helm upgrade scale down and then wait for the autoscaler to climb back. Webhook processors take production webhook traffic, so a warm floor is what keeps a traffic ramp from queueing behind pod startup. | `number` | `2` | no |
 | <a name="input_n8n_webhook_memory_limit"></a> [n8n\_webhook\_memory\_limit](#input\_n8n\_webhook\_memory\_limit) | Memory limit for n8n webhook processor pods (e.g. 1Gi, 2Gi) | `string` | `"1Gi"` | no |
 | <a name="input_n8n_webhook_memory_request"></a> [n8n\_webhook\_memory\_request](#input\_n8n\_webhook\_memory\_request) | Memory request for n8n webhook processor pods (e.g. 512Mi, 1Gi) | `string` | `"512Mi"` | no |
 | <a name="input_n8n_webhook_url"></a> [n8n\_webhook\_url](#input\_n8n\_webhook\_url) | Public HTTPS base URL used for webhook callbacks (e.g. https://webhooks.example.com). Defaults to https://<n8n\_domain> when not set. Override when webhooks are served from a different host than the n8n UI. | `string` | `null` | no |
@@ -644,14 +743,14 @@ No modules.
 | <a name="input_n8n_worker_cpu_limit"></a> [n8n\_worker\_cpu\_limit](#input\_n8n\_worker\_cpu\_limit) | CPU limit for n8n worker pods (e.g. 1000m, 2000m) | `string` | `"1000m"` | no |
 | <a name="input_n8n_worker_cpu_request"></a> [n8n\_worker\_cpu\_request](#input\_n8n\_worker\_cpu\_request) | CPU request for n8n worker pods (e.g. 500m, 1000m) | `string` | `"500m"` | no |
 | <a name="input_n8n_worker_keda_jobs_per_replica"></a> [n8n\_worker\_keda\_jobs\_per\_replica](#input\_n8n\_worker\_keda\_jobs\_per\_replica) | Number of waiting jobs per worker replica used as the KEDA scaling threshold. KEDA targets ceil(queue\_depth / jobs\_per\_replica) replicas. | `number` | `5` | no |
-| <a name="input_n8n_worker_keda_max_replicas"></a> [n8n\_worker\_keda\_max\_replicas](#input\_n8n\_worker\_keda\_max\_replicas) | Maximum worker replicas KEDA may scale to. | `number` | `10` | no |
-| <a name="input_n8n_worker_keda_min_replicas"></a> [n8n\_worker\_keda\_min\_replicas](#input\_n8n\_worker\_keda\_min\_replicas) | Minimum worker replicas. KEDA keeps at least this many workers running even when the queue is empty. | `number` | `1` | no |
+| <a name="input_n8n_worker_keda_max_replicas"></a> [n8n\_worker\_keda\_max\_replicas](#input\_n8n\_worker\_keda\_max\_replicas) | Maximum worker replicas KEDA may scale to. Workers compete for the same nodes as the main and webhook pods, and each carries a task runner sidecar, so this ceiling counts against the same node group budget as the two HPA maxima. See README.md → "Sizing autoscaling against node capacity". | `number` | `10` | no |
+| <a name="input_n8n_worker_keda_min_replicas"></a> [n8n\_worker\_keda\_min\_replicas](#input\_n8n\_worker\_keda\_min\_replicas) | Minimum worker replicas. KEDA keeps at least this many workers running even when the queue is empty. Also becomes the deployment's own replica count: the Helm chart renders spec.replicas unconditionally, so leaving it below the autoscaler floor would make every helm upgrade scale down and then wait for the autoscaler to climb back. | `number` | `1` | no |
 | <a name="input_n8n_worker_memory_limit"></a> [n8n\_worker\_memory\_limit](#input\_n8n\_worker\_memory\_limit) | Memory limit for n8n worker pods (e.g. 2Gi, 4Gi) | `string` | `"2Gi"` | no |
 | <a name="input_n8n_worker_memory_request"></a> [n8n\_worker\_memory\_request](#input\_n8n\_worker\_memory\_request) | Memory request for n8n worker pods (e.g. 1Gi, 2Gi) | `string` | `"1Gi"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy n8n into | `string` | `"n8n"` | no |
 | <a name="input_node_desired"></a> [node\_desired](#input\_node\_desired) | Initial number of worker nodes. Only applies at creation: the node group's desired\_size ignores changes afterward so the Cluster Autoscaler can own it without fighting plans/applies. | `number` | `3` | no |
 | <a name="input_node_instance_type"></a> [node\_instance\_type](#input\_node\_instance\_type) | EC2 instance type for EKS worker nodes. t3.xlarge (4 vCPU, 16GB) is the recommended minimum for multi-main — the 6 n8n pods (main × 2, worker × 2, webhook × 2) request ~3,600m CPU at minimum replicas, leaving t3.medium nodes with insufficient headroom for HPA to scale. | `string` | `"t3.xlarge"` | no |
-| <a name="input_node_max"></a> [node\_max](#input\_node\_max) | Maximum number of worker nodes | `number` | `6` | no |
+| <a name="input_node_max"></a> [node\_max](#input\_node\_max) | Maximum number of worker nodes. This is the ceiling the Cluster Autoscaler scales to, so node\_max × node\_instance\_type is the hard cap on schedulable CPU: the autoscaler maxima (n8n\_main\_hpa\_max\_replicas, n8n\_webhook\_hpa\_max\_replicas, n8n\_worker\_keda\_max\_replicas) and the per-pod CPU requests have to fit inside it. The module warns at plan time when they do not; see README.md → "Sizing autoscaling against node capacity". | `number` | `6` | no |
 | <a name="input_node_min"></a> [node\_min](#input\_node\_min) | Minimum number of worker nodes | `number` | `3` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | IDs of private subnets (one per AZ, minimum two AZs). RDS, ElastiCache, and EKS nodes attach here. | `list(string)` | n/a | yes |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | IDs of public subnets (one per AZ, minimum two AZs). The ALB attaches here. | `list(string)` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -564,9 +564,10 @@ plan. It is exact for 995 of the 1,150 instance types EC2 currently offers in
 eu-west-1. Bare-metal sizes silence the check entirely, as does a CPU request in
 a form the module cannot parse. Of the remaining deviations, the 1 vCPU families
 and the SMT-disabled and legacy sizes are over-counted, which costs a warning
-rather than raising a false one. Three legacy types are under-counted
-(`c1.xlarge`, `c4.8xlarge`, `d2.8xlarge`), so on those the check can warn a hair
-early at the boundary.
+rather than raising a false one. Three legacy types are under-counted, so on
+those the check can warn early: `c4.8xlarge` and `d2.8xlarge` resolve 11% low,
+which warns a hair early at the boundary, and `c1.xlarge` resolves 4 vCPU
+against a real 8, which warns at about half the node group's real capacity.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ Six runnable examples ship with the module: three sizing tiers (`small`, `medium
 | DB IOPS ceiling | 150 baseline / 3,000 burst | 3,000 baseline (gp3) | None — I/O-Optimized |
 | PgBouncer | No | No | Yes — 2 replicas |
 | Redis | cache.t3.medium | cache.r6g.large | cache.r6g.large |
-| Webhook pods min / max | 2 / 50 | 5 / 50 | 30 / 80 |
+| Main pods min / max | 2 / 6 | 3 / 24 | 6 / 60 |
+| Webhook pods min / max | 2 / 8 | 5 / 50 | 30 / 80 |
 | Worker pods min / max | 1 / 10 | 5 / 40 | 20 / 160 |
 | Worker concurrency | 10 | 20 | 40 |
 | Execution concurrency limit | 100 | 200 | 2,000 |
@@ -561,8 +562,11 @@ The check derives vCPU from the instance size rather than calling the EC2 API,
 so that an undeterminable value can never turn an advisory warning into a failed
 plan. It is exact for 995 of the 1,150 instance types EC2 currently offers in
 eu-west-1. Bare-metal sizes silence the check entirely, as does a CPU request in
-a form the module cannot parse; the remaining deviations are legacy and 1 vCPU
-families that make the check quieter, not noisier.
+a form the module cannot parse. Of the remaining deviations, the 1 vCPU families
+and the SMT-disabled and legacy sizes are over-counted, which costs a warning
+rather than raising a false one. Three legacy types are under-counted
+(`c1.xlarge`, `c4.8xlarge`, `d2.8xlarge`), so on those the check can warn a hair
+early at the boundary.
 
 ## Reference
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -235,6 +235,49 @@ is not overridden to `true` unless you deliberately run a single main
    kubectl exec -n <namespace> <main-pod> -c n8n-main -- n8n license:info
    ```
 
+## Pods stay `Pending` with `Insufficient cpu` and the node group never grows
+
+**Symptom**
+
+Some n8n pods never schedule. `kubectl describe pod` reports:
+
+```
+0/6 nodes are available: 6 Insufficient cpu
+```
+
+The Cluster Autoscaler adds no nodes, and its logs say the node group is already
+at its maximum size. It usually shows up during a rolling update, which stalls
+while the surging ReplicaSet competes for the same exhausted CPU.
+
+**Cause**
+
+An autoscaler ceiling is set above what the node group can ever schedule. The
+HPAs and KEDA scale toward their maxima regardless of whether the nodes exist,
+and the Cluster Autoscaler stops at `node_max`. Confirm with:
+
+```bash
+# What the autoscalers are aiming for
+kubectl -n <namespace> get hpa
+kubectl -n <namespace> get scaledobject
+
+# What the nodes can actually give
+kubectl get nodes -o custom-columns='NODE:.metadata.name,ALLOCATABLE_CPU:.status.allocatable.cpu'
+kubectl describe node <node> | sed -n '/Allocated resources/,/^Events/p'
+```
+
+**Fix**
+
+Size the three coupled input groups together: the autoscaler ceilings, the
+per-pod CPU requests, and `node_instance_type` × `node_max`. See
+[README.md → Sizing autoscaling against node capacity](../README.md#sizing-autoscaling-against-node-capacity)
+for the arithmetic and the per-node rule of thumb.
+
+The module warns about this at plan time, so `terraform plan` will already be
+reporting `Warning: Check block assertion failed` with the two numbers. Module
+versions up to 0.2.0 defaulted `n8n_main_hpa_max_replicas` to `20` and
+`n8n_webhook_hpa_max_replicas` to `50`, neither of which fits the default node
+group; upgrading lowers both to values that do.
+
 ## `terraform destroy` hangs on namespace or finalizers
 
 See [destroy-cleanup.md](./destroy-cleanup.md).

--- a/examples/large/README.md
+++ b/examples/large/README.md
@@ -7,7 +7,7 @@ Production-grade n8n for **~50–60M executions per day** (~350–960 req/s aver
 ```
 Route 53 (alias A-record)
     └─► ALB (AWS LBC) ──► EKS (10–50 × m7i.4xlarge)
-                               ├─► n8n main pods (HPA)
+                               ├─► n8n main pods (HPA, min=6 / max=60)
                                ├─► n8n webhook processors (HPA, min=30 / max=80)
                                └─► n8n workers (KEDA, min=20 / max=160)
                                         ├─► PgBouncer (2 replicas, transaction mode)
@@ -25,8 +25,9 @@ Route 53 (alias A-record)
 | VPC CNI tuning | WARM_ENI_TARGET=0, WARM_IP_TARGET=2 | Reduces pre-warmed IPs from ~2,400 to 20 across 10 nodes |
 | Database | Aurora PostgreSQL I/O-Optimized | Removes IOPS ceiling; 14,000–15,000 TPS sustained vs ~600 req/s ceiling on RDS gp3 |
 | Aurora instances | 1 writer + 1 reader | Automatic failover; reader offloads reporting queries |
-| PgBouncer | 2 replicas, transaction mode | 80 webhook + 160 worker + 2 main = 1,210 connections without pooling; transaction mode confirmed compatible with n8n TypeORM |
+| PgBouncer | 2 replicas, transaction mode | 1,500 client connections at the pod ceilings (80 webhook + 160 worker + 60 main, pool_size=5); `MAX_CLIENT_CONN=3000` per replica, so a single surviving replica absorbs all of them; transaction mode confirmed compatible with n8n TypeORM |
 | Redis | cache.r6g.large | 77% peak memory at 856 req/s with no evictions or rejected connections |
+| Main pods | min=6, max=60 | Mains serve the editor and REST API only, not webhooks or manual executions, so the ceiling tracks concurrent users rather than executions/day; 10× the module default, the same factor this tier scales the webhook ceiling by. Floor of 6 keeps warm editor/API capacity, since n8n pods take tens of seconds to boot |
 | Webhook pods | min=30, max=80 | 10 pods saturated at ~960 req/s; 30 pod floor handles 500 concurrent VUs cleanly |
 | Worker pods | min=20, max=160 | 856 req/s ÷ concurrency=40 = 22 workers at steady state; 160 max for 2,400 req/s burst |
 | Worker concurrency | 40 | Doubles throughput per pod vs 20; pool_size=5 is sufficient with PgBouncer |

--- a/examples/large/main.tf
+++ b/examples/large/main.tf
@@ -120,10 +120,12 @@ module "n8n" {
   # floor of 2 would put an API burst behind pod startup, and it leaves nothing
   # spare during a rollout on a tier where mains span only two AZs.
   #
-  # Neither the node group nor PgBouncer is the constraint: at the ceiling,
-  # 72,000m of the ~785,000m this node group can schedule, and 300 client
-  # connections at pool_size=5 against a MAX_CLIENT_CONN of 3,000 per PgBouncer
-  # replica.
+  # Neither the node group nor PgBouncer is the constraint. Main pods alone at
+  # this ceiling request 72,000m and open 300 client connections at pool_size=5.
+  # With all three families at their ceilings at once, which is what the node
+  # group has to survive, it is 208,000m of the ~785,000m this node group can
+  # schedule (60 × 1,200m main, 160 × 700m worker, 80 × 300m webhook) and ~1,500
+  # client connections against a MAX_CLIENT_CONN of 3,000 per PgBouncer replica.
   n8n_main_hpa_min_replicas = 6
   n8n_main_hpa_max_replicas = 60
 

--- a/examples/large/main.tf
+++ b/examples/large/main.tf
@@ -108,6 +108,25 @@ module "n8n" {
   # timeouts. PgBouncer's own server-pool sizing lives in pgbouncer.tf.
   db_postgresdb_pool_size = 5
 
+  # ── Main pods ─────────────────────────────────────────────────────────────────
+  # Mains carry neither webhooks (disableProductionWebhooksOnMainProcess) nor
+  # manual executions (the chart sets OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS), so
+  # this ceiling tracks concurrent editor and REST API users rather than the
+  # ~50-60M executions/day this tier targets. 60 is 10× the module default, the
+  # same factor this tier already scales the webhook ceiling by (8 to 80).
+  #
+  # Floor of 6 keeps warm capacity for the editor and API the way the webhook
+  # floor of 30 does for webhooks. n8n pods take tens of seconds to boot, so a
+  # floor of 2 would put an API burst behind pod startup, and it leaves nothing
+  # spare during a rollout on a tier where mains span only two AZs.
+  #
+  # Neither the node group nor PgBouncer is the constraint: at the ceiling,
+  # 72,000m of the ~785,000m this node group can schedule, and 300 client
+  # connections at pool_size=5 against a MAX_CLIENT_CONN of 3,000 per PgBouncer
+  # replica.
+  n8n_main_hpa_min_replicas = 6
+  n8n_main_hpa_max_replicas = 60
+
   # ── Webhook processors ────────────────────────────────────────────────────────
   # Floor of 30: 10 pods saturated at ~960 req/s in benchmarks; 30 handles
   # 500 concurrent VUs cleanly. 4 Gi memory limit halved failure rate vs 2 Gi

--- a/examples/medium/README.md
+++ b/examples/medium/README.md
@@ -7,7 +7,7 @@ Production-grade n8n for **~5–15M executions per day** (~60–175 req/s averag
 ```
 Route 53 (alias A-record)
     └─► ALB (AWS LBC) ──► EKS (5–15 × m6i.2xlarge)
-                               ├─► n8n main pods (HPA)
+                               ├─► n8n main pods (HPA, min=3 / max=24)
                                ├─► n8n webhook processors (HPA, min=5 / max=50)
                                └─► n8n workers (KEDA, min=5 / max=40)
                                         ├─► RDS PostgreSQL db.m6g.2xlarge (Multi-AZ)
@@ -23,7 +23,8 @@ Route 53 (alias A-record)
 | DB class | db.m6g.2xlarge | Memory-optimized; keeps execution_entity working set in shared_buffers |
 | DB storage | 200 GB gp3 | 3,000 baseline IOPS (vs gp2 burst); no IOPS ceiling at this throughput |
 | Redis | cache.r6g.large | ~4× the memory of cache.t3.medium; comfortable headroom at 175 req/s |
-| Webhook pods | min=5, max=50 | Floor of 5 is warm; 50 ceiling differentiates from the default example's 2/50 floor while keeping the same headroom |
+| Main pods | min=3, max=24 | Mains serve the editor and REST API only, not webhooks or manual executions, so the ceiling tracks concurrent users rather than executions/day; 4× the module default, matching how the worker ceiling scales. Floor of 3 keeps two serving the editor through a node drain |
+| Webhook pods | min=5, max=50 | Floor of 5 is warm; 50 ceiling raises both the floor and the ceiling over the module default of 2/8 |
 | Worker pods | min=5, max=40 | Queue-driven via KEDA; floor ensures fast queue drain at any time |
 | Worker concurrency | 20 | Doubles throughput per pod vs default; pool_size=10 matches |
 | Pruning | 7 days / 500k records | Keeps execution_entity at manageable size without losing debug history |

--- a/examples/medium/main.tf
+++ b/examples/medium/main.tf
@@ -82,10 +82,26 @@ module "n8n" {
   # ── Redis ─────────────────────────────────────────────────────────────────────
   redis_node_type = "cache.r6g.large"
 
+  # ── Main pods ─────────────────────────────────────────────────────────────────
+  # Mains carry neither webhooks (disableProductionWebhooksOnMainProcess) nor
+  # manual executions (the chart sets OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS), so
+  # this ceiling tracks concurrent editor and REST API users rather than this
+  # tier's executions/day. 24 is 4× the module default, matching how the worker
+  # ceiling scales from the default 10 to this tier's 40.
+  #
+  # Floor of 3 matches the warm-floor approach the webhook and worker pods take
+  # here: one leader plus two followers, so a node drain still leaves two serving
+  # the editor while the PodDisruptionBudget only guarantees one.
+  #
+  # Costs 28,800m of the ~115,000m this node group can schedule at the ceiling,
+  # and 240 of db.m6g.2xlarge's ~3,600 connections at pool_size=10.
+  n8n_main_hpa_min_replicas = 3
+  n8n_main_hpa_max_replicas = 24
+
   # ── Webhook processors ────────────────────────────────────────────────────────
   # Minimum floor of 5 ensures warm pods are ready before traffic ramps.
-  # Max of 50 differentiates this tier from the default example's 2/50 by
-  # raising the warm floor; same ceiling handles multi-day traffic spikes.
+  # Max of 50 raises both the warm floor and the ceiling over the module default
+  # (2/8), which this tier's node group has the CPU to schedule.
   # 2 Gi memory limit prevents OOM under concurrent in-flight requests.
   n8n_webhook_hpa_min_replicas = 5
   n8n_webhook_hpa_max_replicas = 50

--- a/n8n.tf
+++ b/n8n.tf
@@ -77,9 +77,23 @@ resource "helm_release" "n8n" {
       activationKey = var.n8n_license_key
     }
 
+    # ── Deployment replica counts ─────────────────────────────────────────────
+    # Each of the three below is wired to its autoscaler's floor rather than left
+    # at a constant, because the chart renders spec.replicas unconditionally:
+    # deployment-main.yaml uses multiMain.replicas, deployment-worker.yaml uses
+    # queueMode.workerReplicaCount, and deployment-webhook-processor.yaml uses
+    # webhookProcessor.replicaCount, with no regard for whether an HPA or a KEDA
+    # ScaledObject also owns the field.
+    #
+    # A constant here fights the autoscaler on every helm upgrade. Helm writes
+    # spec.replicas back to the constant, the deployment scales down to it, and
+    # the autoscaler then has to scale back up to its floor, which erases the warm
+    # floor at exactly the moment a rollout needs it. Setting each to its floor
+    # makes Helm's write a no-op.
+
     multiMain = {
       enabled  = true
-      replicas = 2
+      replicas = var.n8n_main_hpa_min_replicas
       antiAffinity = {
         type = "preferred"
       }
@@ -87,13 +101,13 @@ resource "helm_release" "n8n" {
 
     queueMode = {
       enabled            = true
-      workerReplicaCount = 2
+      workerReplicaCount = var.n8n_worker_keda_min_replicas
       workerConcurrency  = var.n8n_worker_concurrency
     }
 
     webhookProcessor = {
       enabled                                = true
-      replicaCount                           = 2
+      replicaCount                           = var.n8n_webhook_hpa_min_replicas
       disableProductionWebhooksOnMainProcess = true
     }
 

--- a/n8n.tf
+++ b/n8n.tf
@@ -89,7 +89,16 @@ resource "helm_release" "n8n" {
     # spec.replicas back to the constant, the deployment scales down to it, and
     # the autoscaler then has to scale back up to its floor, which erases the warm
     # floor at exactly the moment a rollout needs it. Setting each to its floor
-    # makes Helm's write a no-op.
+    # makes Helm's write a no-op while the deployment sits at that floor.
+    #
+    # It does not preserve an active scale-up. A deployment the autoscaler has
+    # taken above its floor is still written down to the floor on the next
+    # upgrade, and the autoscaler has to climb again. Bounding the drop at the
+    # floor is the most a caller of this chart can do: the field is rendered
+    # unconditionally, so no value omits it, and reading the live replica count
+    # back into the plan would make every plan depend on current cluster state.
+    # Fixing it properly means the chart guarding spec.replicas on whether an
+    # autoscaler owns the deployment.
 
     multiMain = {
       enabled  = true

--- a/scaling.tf
+++ b/scaling.tf
@@ -33,3 +33,211 @@ resource "kubernetes_horizontal_pod_autoscaler_v2" "n8n_webhook" {
 
   depends_on = [helm_release.n8n]
 }
+
+# ── Autoscaling capacity model ────────────────────────────────────────────────
+# Three variable groups have to be sized together, and nothing in Kubernetes
+# couples them: the autoscaler ceilings (n8n_main_hpa_max_replicas,
+# n8n_webhook_hpa_max_replicas, n8n_worker_keda_max_replicas), the per-pod CPU
+# requests, and the node group (node_instance_type × node_max). Set a ceiling
+# above what the node group can ever hold and the autoscalers will still scale
+# toward it: pods pile up Pending with "Insufficient cpu" while the Cluster
+# Autoscaler sits at node_max with nothing left to add. That churn also delays
+# rollouts, because a surging ReplicaSet competes for the same exhausted CPU.
+# See https://github.com/n8n-io/terraform-aws-n8n/issues/51.
+#
+# The locals below model the CPU side of that arithmetic so the check at the
+# bottom of this file can warn at plan time. CPU is the binding constraint at
+# the module's defaults; memory is modelled the same way in principle but is not
+# what runs out first, so it is deliberately left out rather than half-modelled.
+#
+# The model is deliberately pure: no data source reads AWS for the instance
+# type's vCPU count. data.aws_ec2_instance_type would be more precise, but a
+# check block whose condition is unknown at plan is a hard error rather than a
+# warning (see AGENTS.md), and a data source read is exactly the thing that can
+# be deferred to apply. That would turn an advisory sizing hint into a broken
+# plan. Deriving vCPU from the instance size instead keeps the check unable to
+# fail a plan it was only ever meant to annotate.
+
+locals {
+  # Kubernetes CPU quantities are either a core count ("1", "1.5") or millicores
+  # ("500m"). Normalize to millicores so they can be summed.
+  #
+  # can() guards a quantity in a form this module cannot read. That drops
+  # n8n_capacity_model_readable to false and the check below stays silent, rather
+  # than failing the plan over an input Kubernetes itself would have rejected at
+  # apply. Unreadable entries fall back to 0 rather than null, because a check
+  # block evaluates its error_message alongside its condition and null operands
+  # in the interpolated arithmetic would abort the plan outright.
+  n8n_cpu_requests = {
+    main = var.n8n_main_cpu_request
+    # A task runner sidecar rides on main and worker pods only. The chart adds
+    # the container in deployment-main.yaml and deployment-worker.yaml, not in
+    # deployment-webhook-processor.yaml, so webhook processors carry no sidecar
+    # cost below.
+    task_runner = var.n8n_task_runners_enabled ? var.n8n_task_runner_cpu_request : "0"
+    webhook     = var.n8n_webhook_cpu_request
+    worker      = var.n8n_worker_cpu_request
+  }
+
+  n8n_cpu_requests_readable = alltrue([
+    for quantity in values(local.n8n_cpu_requests) : can(tonumber(trimsuffix(quantity, "m")))
+  ])
+
+  n8n_cpu_request_millis = {
+    for name, quantity in local.n8n_cpu_requests : name => (
+      can(tonumber(trimsuffix(quantity, "m")))
+      ? (endswith(quantity, "m") ? tonumber(trimsuffix(quantity, "m")) : tonumber(quantity) * 1000)
+      : 0
+    )
+  }
+
+  # What the three pod families request when every autoscaler sits at its
+  # ceiling simultaneously. Not a forecast: the point is that this number must
+  # be schedulable at all, because each autoscaler can independently reach its
+  # own maximum.
+  n8n_peak_cpu_request_millis = local.n8n_cpu_requests_readable ? (
+    var.n8n_main_hpa_max_replicas * (local.n8n_cpu_request_millis["main"] + local.n8n_cpu_request_millis["task_runner"]) +
+    var.n8n_worker_keda_max_replicas * (local.n8n_cpu_request_millis["worker"] + local.n8n_cpu_request_millis["task_runner"]) +
+    var.n8n_webhook_hpa_max_replicas * local.n8n_cpu_request_millis["webhook"]
+  ) : 0
+
+  # vCPU per node, read off the instance size rather than from the EC2 API.
+  #
+  # This reads the size suffix only, never the family, which is what keeps it
+  # from going stale. AWS sizes instances on a fixed ladder: "large" is 2 vCPU,
+  # "xlarge" is 4, and every "Nxlarge" is 4N. c5.9xlarge is 36, m5.24xlarge is
+  # 96, x1e.32xlarge is 128. Sizes below "large" (nano through medium) are 2 on
+  # every current generation. A family AWS ships next year lands on the same
+  # ladder, so m8i.4xlarge resolves to 16 with no change here, and the Nxlarge
+  # arm is arithmetic rather than a table, so a size larger than any that exists
+  # today resolves too.
+  #
+  # Against the 1,150 instance types ec2:DescribeInstanceTypes reports in
+  # eu-west-1, this resolves 995 exactly, leaves 104 off the ladder, over-counts
+  # 48 and under-counts 3.
+  #
+  #   - Off-ladder is exactly the bare-metal set ("metal" through "metal-96xl").
+  #     Those leave node_vcpus_derived null, the model goes unreadable, and the
+  #     check says nothing at all rather than warning off a guess.
+  #   - Over-counts are ".medium" on the 1 vCPU families (Graviton, c7a/c8a/m7a
+  #     and friends), the SMT-disabled hpc7a sizes, and the pre-2015 m1/m2/t1/t2
+  #     legacy types. An over-count makes the check think there is more room than
+  #     there is, so it costs a warning rather than raising a false one.
+  #   - Under-counts are three legacy types only: c1.xlarge (8, not 4) and
+  #     c4/d2.8xlarge (36, not 32). c4 and d2 are 11% low, enough to warn a hair
+  #     early at the boundary and nothing more.
+  #
+  # None of this affects the deployment: these locals feed the advisory check
+  # below and nothing else.
+  node_size = element(split(".", var.node_instance_type), 1)
+
+  node_vcpus_derived = (
+    can(regex("^[0-9]+xlarge$", local.node_size))
+    ? tonumber(trimsuffix(local.node_size, "xlarge")) * 4
+    : lookup({
+      xlarge = 4
+      large  = 2
+      medium = 2
+      small  = 2
+      micro  = 2
+      nano   = 2
+    }, local.node_size, null)
+  )
+
+  # Zero stands in for an unreadable size everywhere below. A check block
+  # evaluates its error_message alongside its condition, so a null reaching the
+  # message's interpolated arithmetic would abort the plan instead of letting
+  # n8n_capacity_model_readable quietly suppress the warning.
+  node_vcpus = coalesce(local.node_vcpus_derived, 0)
+
+  # EKS does not hand a node's full vCPU count to pods. The AMI's bootstrap
+  # script reserves CPU for kubelet and the container runtime on a tiered curve
+  # (get_cpu_millicores_to_reserve): 6% of the first vCPU, 1% of the second,
+  # 0.5% of the third and fourth, 0.25% of every vCPU beyond. A t3.xlarge
+  # (4 vCPU) therefore reports 3,920m allocatable, not 4,000m.
+  node_kube_reserved_cpu_millis = local.node_vcpus == 0 ? 0 : (
+    60
+    + (local.node_vcpus >= 2 ? 10 : 0)
+    + min(max(local.node_vcpus - 2, 0), 2) * 5
+    + max(local.node_vcpus - 4, 0) * 2.5
+  )
+
+  # DaemonSets that land on every node and claim their requests ahead of any n8n
+  # pod. These are the requests the containers declare on a cluster this module
+  # builds, which is not always what the upstream charts document:
+  #
+  #   aws-node                 50m   (aws-node 25m + aws-eks-nodeagent 25m)
+  #   kube-proxy              100m
+  #   ebs-csi-node             30m   (3 containers × 10m, from storage.tf)
+  #   eks-pod-identity-agent    0m   (declares no requests)
+  #
+  # ebs-csi-node-windows is excluded deliberately: it exists in kube-system but
+  # reports desiredNumberScheduled = 0, because no node here matches its Windows
+  # selector. Counting it would overstate overhead by 30m per node.
+  node_daemonset_cpu_millis = 180
+
+  node_schedulable_cpu_millis = max(
+    local.node_vcpus * 1000 - local.node_kube_reserved_cpu_millis - local.node_daemonset_cpu_millis,
+    0,
+  )
+
+  # Cluster-wide singletons come off the total once rather than per node:
+  #
+  #   CoreDNS                            200m   (100m × 2 replicas)
+  #   metrics-server                     100m
+  #   KEDA operator / metrics / webhooks 300m   (100m × 3)
+  #   ebs-csi-controller                 120m   (6 containers × 10m × 2 replicas)
+  #
+  # The AWS Load Balancer Controller and Cluster Autoscaler charts declare no
+  # requests at the versions this module installs, so they cost nothing against a
+  # request-based model. Still an approximation, since a caller's own workloads
+  # and DaemonSets are invisible here, which is why the check below only warns.
+  cluster_addon_cpu_millis = 720
+
+  n8n_schedulable_cpu_millis = max(
+    var.node_max * local.node_schedulable_cpu_millis - local.cluster_addon_cpu_millis,
+    0,
+  )
+
+  # Both halves of the comparison have to be readable for the warning to mean
+  # anything. Either an unparseable CPU quantity or an instance size off the
+  # standard ladder silences the check instead of warning off a guess.
+  n8n_capacity_model_readable = local.n8n_cpu_requests_readable && local.node_vcpus_derived != null
+}
+
+# Warns, rather than fails, for two reasons. The model is an approximation (the
+# add-on allowance above is a constant, and a caller may run their own
+# DaemonSets or workloads on these nodes), and a caller may deliberately want
+# ceilings the current node group cannot reach because node_max is the next
+# thing they plan to raise. Blocking either case would be wrong.
+#
+# Terraform evaluates a check block's error_message alongside its condition, not
+# lazily on failure, so every value interpolated below is evaluated on every
+# plan. That is why the inputs this block reads carry nullable = false. On a
+# nullable variable, a caller writing `x = null` in the module block propagates
+# that null into the input rather than falling back to the default, and a null
+# reaching the interpolations below aborts the plan from inside a block whose
+# entire purpose is to warn without failing. With nullable = false, Terraform
+# substitutes the declared default for an explicit null at the variable boundary,
+# so the model always has numbers to work with.
+check "autoscaling_maxima_fit_node_group_capacity" {
+  assert {
+    condition = local.n8n_capacity_model_readable ? (
+      local.n8n_peak_cpu_request_millis <= local.n8n_schedulable_cpu_millis
+    ) : true
+    error_message = join("", [
+      "Autoscaler maxima exceed the CPU the node group can ever schedule. At their ceilings the n8n pods ",
+      "request ${local.n8n_peak_cpu_request_millis}m CPU ",
+      "(main ${var.n8n_main_hpa_max_replicas} × ${local.n8n_cpu_request_millis["main"] + local.n8n_cpu_request_millis["task_runner"]}m, ",
+      "worker ${var.n8n_worker_keda_max_replicas} × ${local.n8n_cpu_request_millis["worker"] + local.n8n_cpu_request_millis["task_runner"]}m, ",
+      "webhook ${var.n8n_webhook_hpa_max_replicas} × ${local.n8n_cpu_request_millis["webhook"]}m), ",
+      "but ${var.node_max} × ${var.node_instance_type} leaves only about ",
+      "${local.n8n_schedulable_cpu_millis}m for them ",
+      "(${local.node_vcpus} vCPU per node, less kubelet reservations, the aws-node and kube-proxy ",
+      "DaemonSets, and this module's cluster add-ons). The autoscalers will still scale toward those ",
+      "maxima, leaving pods Pending with \"Insufficient cpu\" once the Cluster Autoscaler reaches node_max. ",
+      "Either lower the maxima, lower the CPU requests, or raise node_max / node_instance_type. ",
+      "See README.md → \"Sizing autoscaling against node capacity\".",
+    ])
+  }
+}

--- a/scaling.tf
+++ b/scaling.tf
@@ -174,6 +174,12 @@ locals {
   # ebs-csi-node-windows is excluded deliberately: it exists in kube-system but
   # reports desiredNumberScheduled = 0, because no node here matches its Windows
   # selector. Counting it would overstate overhead by 30m per node.
+  #
+  # Maintenance: this constant is measured, not sourced from a pin. aws-node and
+  # kube-proxy track var.kubernetes_version and ebs-csi-node comes from the
+  # unpinned aws_eks_addon in storage.tf, so re-verify after bumping
+  # kubernetes_version or when the addon moves:
+  #   kubectl -n kube-system get ds -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[*].resources.requests.cpu}{"\n"}{end}'
   node_daemonset_cpu_millis = 180
 
   node_schedulable_cpu_millis = max(
@@ -192,6 +198,13 @@ locals {
   # requests at the versions this module installs, so they cost nothing against a
   # request-based model. Still an approximation, since a caller's own workloads
   # and DaemonSets are invisible here, which is why the check below only warns.
+  #
+  # Maintenance: this constant is measured, not sourced from a pin. CoreDNS
+  # tracks var.kubernetes_version; metrics-server, KEDA and ebs-csi-controller
+  # come from the unpinned charts and addon in controllers.tf, keda.tf and
+  # storage.tf, so a chart release can move these requests without any change in
+  # this repo. Re-verify after bumping kubernetes_version or upgrading a cluster:
+  #   kubectl -n kube-system get deploy -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[*].resources.requests.cpu}{"\n"}{end}'
   cluster_addon_cpu_millis = 720
 
   n8n_schedulable_cpu_millis = max(

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -31,6 +31,7 @@ mock_provider "aws" {
     }
   }
 
+
   override_data {
     target = data.aws_caller_identity.current
     values = {
@@ -1794,4 +1795,291 @@ run "image_tag_rejects_overlong_tag" {
   }
 
   expect_failures = [var.n8n_image_tag]
+}
+
+# ── Autoscaling capacity against the node group ──────────────────────────────
+# The autoscaler ceilings, the per-pod CPU requests, and node_max ×
+# node_instance_type have to be sized together: nothing in Kubernetes couples
+# them, so a ceiling above what the node group can hold just produces Pending
+# pods once the Cluster Autoscaler runs out of nodes (issue #51). scaling.tf
+# models the CPU arithmetic and warns; these runs pin both the shipped defaults
+# and the warning's boundaries.
+#
+# The model reads vCPU off the instance size rather than the EC2 API, so these
+# numbers are deterministic under mocks with nothing to override. At the default
+# t3.xlarge: 6 nodes × (4,000m − 80m kubelet reserve − 180m of per-node
+# DaemonSets) − 720m of cluster add-ons ≈ 21,720m available to n8n, against
+# 16,600m requested at the default ceilings. The remainder is headroom for a
+# rollout surge. scaling.tf documents where each constant in that sum comes from.
+
+run "autoscaling_defaults_fit_the_default_node_group" {
+  command = plan
+
+  # No expect_failures: a warning from the capacity check would fail this run,
+  # which is the assertion that matters here. The replica asserts pin the
+  # defaults that make it hold.
+  assert {
+    condition     = kubernetes_horizontal_pod_autoscaler_v2.n8n_webhook.spec[0].max_replicas == 8
+    error_message = "The webhook HPA ceiling must default to 8, which the default node group can schedule alongside the main and worker ceilings"
+  }
+
+  assert {
+    condition     = kubernetes_horizontal_pod_autoscaler_v2.n8n_webhook.spec[0].min_replicas == 2
+    error_message = "The webhook HPA floor must stay at 2 for multi-replica availability"
+  }
+
+  assert {
+    condition     = aws_eks_node_group.n8n.scaling_config[0].max_size == 6
+    error_message = "node_max must default to 6; the HPA and KEDA ceilings are sized against it"
+  }
+}
+
+# The pre-fix defaults: 20 mains at 1,200m each (pod + task runner sidecar) is
+# 24,000m on its own, more than the whole node group can ever schedule.
+run "pre_fix_main_hpa_maximum_warns" {
+  command = plan
+
+  variables {
+    n8n_main_hpa_max_replicas = 20
+  }
+
+  expect_failures = [check.autoscaling_maxima_fit_node_group_capacity]
+}
+
+run "pre_fix_webhook_hpa_maximum_warns" {
+  command = plan
+
+  variables {
+    n8n_webhook_hpa_max_replicas = 50
+  }
+
+  expect_failures = [check.autoscaling_maxima_fit_node_group_capacity]
+}
+
+# Workers are not on an HPA but compete for the same CPU, so their KEDA ceiling
+# is part of the same budget.
+run "worker_keda_maximum_counts_against_the_same_budget" {
+  command = plan
+
+  variables {
+    n8n_worker_keda_max_replicas = 40
+  }
+
+  expect_failures = [check.autoscaling_maxima_fit_node_group_capacity]
+}
+
+# Task runner sidecars ride on main and worker pods only, so turning them off
+# frees 200m per main and per worker. 12 mains is over the line with them
+# (23,800m) and under it without (19,400m). The pair pins that accounting.
+run "main_maximum_of_twelve_warns_with_task_runners_enabled" {
+  command = plan
+
+  variables {
+    n8n_main_hpa_max_replicas = 12
+  }
+
+  expect_failures = [check.autoscaling_maxima_fit_node_group_capacity]
+}
+
+run "main_maximum_of_twelve_fits_without_task_runners" {
+  command = plan
+
+  variables {
+    n8n_main_hpa_max_replicas = 12
+    n8n_task_runners_enabled  = false
+  }
+
+  assert {
+    condition     = kubernetes_horizontal_pod_autoscaler_v2.n8n_webhook.spec[0].max_replicas == 8
+    error_message = "Disabling task runners must not disturb the webhook ceiling"
+  }
+}
+
+# Raising node_max is the other side of the same equation: the maxima that warn
+# above are fine once there is somewhere to put the pods.
+run "raising_node_max_admits_higher_maxima" {
+  command = plan
+
+  variables {
+    node_max                     = 14
+    n8n_main_hpa_max_replicas    = 20
+    n8n_webhook_hpa_max_replicas = 50
+  }
+
+  assert {
+    condition     = aws_eks_node_group.n8n.scaling_config[0].max_size == 14
+    error_message = "node_max must reach the node group so the capacity model reflects it"
+  }
+}
+
+# A bigger instance type buys the same headroom as more nodes. m6i.2xlarge is
+# 8 vCPU off the size ladder, so 6 of them roughly doubles what 6 t3.xlarge give.
+run "a_larger_instance_type_admits_higher_maxima" {
+  command = plan
+
+  variables {
+    node_instance_type           = "m6i.2xlarge"
+    n8n_main_hpa_max_replicas    = 20
+    n8n_webhook_hpa_max_replicas = 20
+  }
+
+  assert {
+    condition     = one(aws_eks_node_group.n8n.instance_types) == "m6i.2xlarge"
+    error_message = "node_instance_type must reach the node group so the capacity model reflects it"
+  }
+}
+
+# ...and the ladder has to be read, not assumed. 4 × m6i.2xlarge is 8 vCPU × 4,
+# which the same maxima do not fit into, so this run proves the size suffix is
+# actually parsed rather than treated as a constant.
+run "the_instance_size_ladder_is_read_not_assumed" {
+  command = plan
+
+  variables {
+    node_instance_type           = "m6i.2xlarge"
+    node_max                     = 4
+    n8n_main_hpa_max_replicas    = 20
+    n8n_webhook_hpa_max_replicas = 20
+  }
+
+  expect_failures = [check.autoscaling_maxima_fit_node_group_capacity]
+}
+
+# Sizes off the standard ladder ("metal" and its variants) have no derivable vCPU
+# count, so the model goes unreadable and the check stays silent rather than
+# warning off a guess. The ceiling here would warn loudly on any ladder size.
+run "an_off_ladder_instance_size_silences_the_capacity_check" {
+  command = plan
+
+  variables {
+    node_instance_type        = "m5.metal"
+    n8n_main_hpa_max_replicas = 200
+  }
+
+  assert {
+    condition     = one(aws_eks_node_group.n8n.instance_types) == "m5.metal"
+    error_message = "An instance size the model cannot read must still reach the node group"
+  }
+}
+
+# Likewise for a CPU request in a form the module cannot parse: the ceiling here
+# would warn loudly if the quantity had parsed.
+run "unparseable_cpu_request_silences_the_capacity_check" {
+  command = plan
+
+  variables {
+    n8n_main_cpu_request      = "one and a half cores"
+    n8n_main_hpa_max_replicas = 200
+  }
+
+  assert {
+    condition     = kubernetes_horizontal_pod_autoscaler_v2.n8n_webhook.spec[0].max_replicas == 8
+    error_message = "An unreadable CPU quantity must leave the rest of the plan intact"
+  }
+}
+
+# ── Autoscaler floors drive the deployments' own replica counts ───────────────
+# The chart renders spec.replicas unconditionally on all three deployments,
+# ignoring whether an HPA or a KEDA ScaledObject also owns the field. Left at a
+# constant, every helm upgrade would scale down to it and make the autoscaler
+# climb back, erasing a warm floor exactly when a rollout needs it. n8n.tf wires
+# each replica count to its floor so Helm's write is a no-op.
+#
+# helm_release.values is unknown at plan under mocks (see "Known mock provider
+# limitations" in AGENTS.md), so the wiring itself cannot be asserted here. These
+# runs pin the floors as inputs and the one autoscaler the module owns directly;
+# examples/medium and examples/large exercise raised floors end to end.
+
+run "autoscaler_floors_default_to_warm_multi_replica_values" {
+  command = plan
+
+  assert {
+    condition     = var.n8n_main_hpa_min_replicas == 2 && var.n8n_webhook_hpa_min_replicas == 2
+    error_message = "Main and webhook floors must default to 2; a floor of 1 leaves no replica available during a node drain under the module's PodDisruptionBudget"
+  }
+
+  assert {
+    condition     = kubernetes_horizontal_pod_autoscaler_v2.n8n_webhook.spec[0].min_replicas == var.n8n_webhook_hpa_min_replicas
+    error_message = "The webhook HPA floor must track n8n_webhook_hpa_min_replicas, which is also what the chart writes to spec.replicas"
+  }
+}
+
+run "raised_floors_reach_the_module_owned_webhook_hpa" {
+  command = plan
+
+  variables {
+    n8n_webhook_hpa_min_replicas = 5
+    n8n_worker_keda_min_replicas = 5
+    n8n_main_hpa_min_replicas    = 3
+  }
+
+  assert {
+    condition     = kubernetes_horizontal_pod_autoscaler_v2.n8n_webhook.spec[0].min_replicas == 5
+    error_message = "A raised webhook floor must reach the HPA the module creates in scaling.tf"
+  }
+}
+
+# A floor above the ceiling is rejected by Kubernetes and KEDA at apply, which is
+# a slow way to find a typo now that the floors also drive spec.replicas.
+
+run "main_floor_above_its_ceiling_fails_validation" {
+  command = plan
+
+  variables {
+    n8n_main_hpa_min_replicas = 8
+    n8n_main_hpa_max_replicas = 6
+  }
+
+  expect_failures = [var.n8n_main_hpa_min_replicas]
+}
+
+run "webhook_floor_above_its_ceiling_fails_validation" {
+  command = plan
+
+  variables {
+    n8n_webhook_hpa_min_replicas = 10
+    n8n_webhook_hpa_max_replicas = 8
+  }
+
+  expect_failures = [var.n8n_webhook_hpa_min_replicas]
+}
+
+run "worker_floor_above_its_ceiling_fails_validation" {
+  command = plan
+
+  variables {
+    n8n_worker_keda_min_replicas = 20
+    n8n_worker_keda_max_replicas = 10
+  }
+
+  expect_failures = [var.n8n_worker_keda_min_replicas]
+}
+
+# ── Not testable here: null passed as a module argument ──────────────────────
+# The nine inputs the capacity model reads carry nullable = false. On a nullable
+# variable, a caller passing null in a module block propagates that null instead
+# of falling back to the default, and the check's error_message is evaluated
+# alongside its condition rather than lazily, so a null aborted the plan from
+# inside a block whose whole purpose is to warn without failing.
+#
+# This suite cannot cover it. A run block's `variables` treats `x = null` as
+# *unset*, so the variable takes its default and no error is raised: the two
+# semantics differ, and only the module-call one is the bug. An earlier attempt
+# here failed with "Missing expected failure" for exactly that reason. See
+# "Known mock provider limitations" in AGENTS.md.
+
+# Equal floor and ceiling pins the replica count with no autoscaling range, which
+# is a legitimate way to run a fixed-size deployment.
+run "equal_floor_and_ceiling_is_accepted" {
+  command = plan
+
+  variables {
+    n8n_webhook_hpa_min_replicas = 4
+    n8n_webhook_hpa_max_replicas = 4
+  }
+
+  assert {
+    condition     = kubernetes_horizontal_pod_autoscaler_v2.n8n_webhook.spec[0].min_replicas == kubernetes_horizontal_pod_autoscaler_v2.n8n_webhook.spec[0].max_replicas
+    error_message = "A floor equal to its ceiling must be accepted as a fixed-size deployment"
+  }
 }

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -31,7 +31,6 @@ mock_provider "aws" {
     }
   }
 
-
   override_data {
     target = data.aws_caller_identity.current
     values = {

--- a/variables.tf
+++ b/variables.tf
@@ -193,6 +193,7 @@ variable "node_instance_type" {
   description = "EC2 instance type for EKS worker nodes. t3.xlarge (4 vCPU, 16GB) is the recommended minimum for multi-main — the 6 n8n pods (main × 2, worker × 2, webhook × 2) request ~3,600m CPU at minimum replicas, leaving t3.medium nodes with insufficient headroom for HPA to scale."
   type        = string
   default     = "t3.xlarge"
+  nullable    = false
 
   validation {
     condition     = can(regex("^[a-z][a-z0-9]*\\.[a-z0-9]+$", var.node_instance_type))
@@ -223,9 +224,10 @@ variable "node_min" {
 }
 
 variable "node_max" {
-  description = "Maximum number of worker nodes"
+  description = "Maximum number of worker nodes. This is the ceiling the Cluster Autoscaler scales to, so node_max × node_instance_type is the hard cap on schedulable CPU: the autoscaler maxima (n8n_main_hpa_max_replicas, n8n_webhook_hpa_max_replicas, n8n_worker_keda_max_replicas) and the per-pod CPU requests have to fit inside it. The module warns at plan time when they do not; see README.md → \"Sizing autoscaling against node capacity\"."
   type        = number
   default     = 6
+  nullable    = false
 
   validation {
     condition     = var.node_max >= 1
@@ -438,6 +440,7 @@ variable "n8n_task_runners_enabled" {
   description = "Enable task runner sidecars for isolated JavaScript and Python code execution"
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "n8n_task_runner_cpu_request" {
@@ -635,15 +638,22 @@ variable "n8n_task_runner_request_timeout" {
 # ── HPA: main pods ────────────────────────────────────────────────────────────
 
 variable "n8n_main_hpa_min_replicas" {
-  description = "Minimum replicas for n8n main pods. HPA will not scale below this."
+  description = "Minimum replicas for n8n main pods. HPA will not scale below this. Also becomes the deployment's own replica count: the Helm chart renders spec.replicas unconditionally, so leaving it below the autoscaler floor would make every helm upgrade scale down and then wait for the autoscaler to climb back. Keep at 2 or more for availability: mains serve the editor and REST API, and the module's PodDisruptionBudget only guarantees one during a node drain."
   type        = number
   default     = 2
+  nullable    = false
+
+  validation {
+    condition     = var.n8n_main_hpa_min_replicas <= var.n8n_main_hpa_max_replicas
+    error_message = "n8n_main_hpa_min_replicas must not exceed n8n_main_hpa_max_replicas; Kubernetes rejects an HPA whose minReplicas is above its maxReplicas."
+  }
 }
 
 variable "n8n_main_hpa_max_replicas" {
-  description = "Maximum replicas for n8n main pods. HPA will not scale above this."
+  description = "Maximum replicas for n8n main pods. HPA will not scale above this. The default of 6 is sized to the default node group (node_max × node_instance_type): at the default CPU requests, 6 main pods plus their task runner sidecars, the worker ceiling, and the webhook ceiling all fit in what 6 t3.xlarge nodes can schedule. Raise this together with node_max or node_instance_type. An HPA ceiling the node group cannot hold leaves pods Pending with \"Insufficient cpu\" once the Cluster Autoscaler reaches node_max, which also slows rollouts. The module warns at plan time when the three groups are out of step; see README.md → \"Sizing autoscaling against node capacity\"."
   type        = number
-  default     = 20
+  default     = 6
+  nullable    = false
 }
 
 variable "n8n_main_hpa_cpu_threshold" {
@@ -655,15 +665,22 @@ variable "n8n_main_hpa_cpu_threshold" {
 # ── HPA: webhook processor pods ───────────────────────────────────────────────
 
 variable "n8n_webhook_hpa_min_replicas" {
-  description = "Minimum replicas for n8n webhook processor pods. HPA will not scale below this."
+  description = "Minimum replicas for n8n webhook processor pods. HPA will not scale below this. Also becomes the deployment's own replica count: the Helm chart renders spec.replicas unconditionally, so leaving it below the autoscaler floor would make every helm upgrade scale down and then wait for the autoscaler to climb back. Webhook processors take production webhook traffic, so a warm floor is what keeps a traffic ramp from queueing behind pod startup."
   type        = number
   default     = 2
+  nullable    = false
+
+  validation {
+    condition     = var.n8n_webhook_hpa_min_replicas <= var.n8n_webhook_hpa_max_replicas
+    error_message = "n8n_webhook_hpa_min_replicas must not exceed n8n_webhook_hpa_max_replicas; Kubernetes rejects an HPA whose minReplicas is above its maxReplicas."
+  }
 }
 
 variable "n8n_webhook_hpa_max_replicas" {
-  description = "Maximum replicas for n8n webhook processor pods. HPA will not scale above this."
+  description = "Maximum replicas for n8n webhook processor pods. HPA will not scale above this. The default of 8 is sized to the default node group (node_max × node_instance_type), alongside the main and worker ceilings. Webhook processors are the cheapest pod family to scale (no task runner sidecar, 300m by default), so this is usually the first ceiling to raise once node_max goes up. See n8n_main_hpa_max_replicas and README.md → \"Sizing autoscaling against node capacity\"."
   type        = number
-  default     = 50
+  default     = 8
+  nullable    = false
 }
 
 variable "n8n_webhook_hpa_cpu_threshold" {
@@ -870,15 +887,22 @@ variable "n8n_extra_env" {
 # ── KEDA: worker pods ─────────────────────────────────────────────────────────
 
 variable "n8n_worker_keda_min_replicas" {
-  description = "Minimum worker replicas. KEDA keeps at least this many workers running even when the queue is empty."
+  description = "Minimum worker replicas. KEDA keeps at least this many workers running even when the queue is empty. Also becomes the deployment's own replica count: the Helm chart renders spec.replicas unconditionally, so leaving it below the autoscaler floor would make every helm upgrade scale down and then wait for the autoscaler to climb back."
   type        = number
   default     = 1
+  nullable    = false
+
+  validation {
+    condition     = var.n8n_worker_keda_min_replicas <= var.n8n_worker_keda_max_replicas
+    error_message = "n8n_worker_keda_min_replicas must not exceed n8n_worker_keda_max_replicas; KEDA rejects a ScaledObject whose minReplicaCount is above its maxReplicaCount."
+  }
 }
 
 variable "n8n_worker_keda_max_replicas" {
-  description = "Maximum worker replicas KEDA may scale to."
+  description = "Maximum worker replicas KEDA may scale to. Workers compete for the same nodes as the main and webhook pods, and each carries a task runner sidecar, so this ceiling counts against the same node group budget as the two HPA maxima. See README.md → \"Sizing autoscaling against node capacity\"."
   type        = number
   default     = 10
+  nullable    = false
 }
 
 variable "n8n_worker_keda_jobs_per_replica" {


### PR DESCRIPTION
Resolves #51.

The default HPA maxima were unschedulable by construction. 20 main pods plus their task runner sidecars request 24,000m CPU on their own, which is more than the entire default node group (`node_max = 6` × t3.xlarge = 24 vCPU) can ever provide, before the worker and webhook ceilings are counted at all.

It survived this long because nothing fails loudly. During a rollout with elevated CPU the HPAs scale toward their maxima, the Cluster Autoscaler hits `node_max`, and the pods that don't fit sit `Pending` with `Insufficient cpu` while the surging ReplicaSet competes for the same exhausted CPU. #51 reports 15 such pods and a rollout that only finished once the HPAs were capped by hand.

## What changed

- `n8n_main_hpa_max_replicas` 20 → 6 and `n8n_webhook_hpa_max_replicas` 50 → 8. At the new defaults the three pod families request 16,600m against roughly 21,720m schedulable.
- A plan-time `check` that warns when the autoscaler ceilings, the per-pod CPU requests, and `node_max` × `node_instance_type` are out of step. Nothing in Kubernetes couples those three, so nothing tells you until pods are already `Pending`.
- New README section, "Sizing autoscaling against node capacity", plus a `docs/troubleshooting.md` entry for the symptom side (`Pending` / `Insufficient cpu` with the node group already at its maximum).
- `examples/medium` and `examples/large` pin the main pod range (3/24 and 6/60) against their own node groups instead of inheriting a starter default. The four small-sizing examples set no node group values at all, so they run the default node group these new defaults are sized for, and inheriting is correct there.
- A `spec.replicas` fix, see question 1 below.

### Why a `check` and not a `validation`

The model is an approximation, and staging higher ceilings before you raise `node_max` is a legitimate thing to do, so blocking either would be wrong.

vCPU is derived from the instance size suffix rather than read from `data.aws_ec2_instance_type`. A `check` whose condition is unknown at plan is a hard error rather than a warning, and a data source read is exactly what Terraform can defer to apply, so the precise version could turn an advisory hint into a broken plan. The suffix ladder is exact for 995 of the 1,150 instance types EC2 offers in eu-west-1. Bare-metal sizes silence the check entirely rather than warning off a guess, 48 sizes are over-counted (which costs a warning rather than raising a false one), and 3 legacy types are under-counted so the check can warn a hair early on those.

## Verification

Verified on a live 3-node cluster in us-east-1 and then destroyed, not checked by inspection. Full evidence is in the CHANGELOG entries. TLDR:

- Reproduced #51 exactly: 21 pods `Pending` with `0/3 nodes are available: 3 Insufficient cpu`, Cluster Autoscaler pinned at `node_max`.
- Measured every supply-side constant against the running cluster, which corrected three of them. The model predicted 10,500m available and the scheduler placed 10,200m. The 300m residue is bin-packing fragmentation, which no request-based model can represent, so read the warning as a bound and not a prediction.
- Reproduced and then confirmed the fix for the `spec.replicas` defect through a pod-churning `helm upgrade`.

CI was run locally on the pinned versions rather than my newer local toolchain (Terraform 1.9.8, terraform-docs v0.22.0, tflint v0.53.0): `fmt`, `terraform-docs --output-check` × 7, `validate` × 7, `test` × 7 (118 module tests plus every example), `tflint` × 7, `checkov`. All green. checkov's 28 findings are pre-existing and sit in files this PR doesn't touch.

## Upgrade impact

Both HPAs update in place with no resource replacement. Two cases need a caller's attention, both written up in `CHANGELOG.md`:

1. A cluster currently running more than 6 main or 8 webhook pods gets scaled back to the new ceiling on the next apply.
2. An explicit floor above the new ceiling fails the plan. `n8n_main_hpa_min_replicas = 8` or `n8n_webhook_hpa_min_replicas = 10` was valid against the old ceilings and isn't against the new ones. That's a caller who changes nothing and gets a plan error, so it's called out explicitly in the upgrade note.

## Two open questions

**1. Should the `spec.replicas` fix be split into its own PR?**

It's an independent defect that this work happened to surface, and it has its own `### Fixed` entry. The chart renders `spec.replicas` unconditionally on all three deployments (`multiMain.replicas`, `queueMode.workerReplicaCount`, `webhookProcessor.replicaCount`), whether or not an HPA or a KEDA ScaledObject also owns the field. The module passed a constant `2`, so every `helm upgrade` scaled main, worker and webhook down to 2 before their autoscalers climbed back.

Worth being precise about what the fix does, because cubic caught me overstating it: wiring each to its autoscaler's floor makes Helm's write a no-op *at rest*, and bounds the drop at the floor under load. It doesn't preserve an active scale-up. A webhook deployment at 80 now drops to 30 on `examples/large` instead of to 2, which is a real improvement and not a cure. Bounding it at the floor is the ceiling of what a chart consumer can do, since the field is rendered unconditionally and no value omits it, and reading the live replica count back into the plan would make every plan depend on cluster state. Eliminating it needs the chart to guard `spec.replicas` on whether an autoscaler owns the deployment. Happy to file that upstream against `n8n-helm-chart` if we agree it's the right ask.

For splitting: a) it isn't what #51 asked for, b) it's separately reviewable, c) it'd be separately revertable. Against: the warm floors this PR introduces for `examples/medium` and `examples/large` are unsafe without it, so shipping the raised floors while every `helm upgrade` still collapses them to 2 would make the regression worse, not better. If we do separate them, the `spec.replicas` fix should land first.

Splitting it back out is mechanical: three lines in `n8n.tf`, its CHANGELOG entry, and the floor wording in three variable descriptions. Happy to do it either way.

**2. The floor-above-ceiling validations went beyond the original ask, but they turned out to be load-bearing.**

Three `validation` blocks reject `min > max` for main, webhook and worker. #51 didn't ask for these, and they're the only hard failure this PR adds.

I originally flagged them as removable. They aren't. Lowering the two default ceilings is precisely what makes `min > max` reachable for a caller who changes nothing, which is upgrade case 2 above. Without them, that caller's plan succeeds and the apply fails partway through, with the Kubernetes API rejecting the HPA instead of Terraform naming the two inputs and their values.

Worth a second pair of eyes on the choice of a hard `validation` here while the capacity model next door is only a `check`. The distinction is deliberate: `min > max` is invariably rejected by Kubernetes and KEDA, whereas a ceiling above current node capacity is something a caller might legitimately be staging.

Thoughts?
