### PR TITLE
fix(eks): ignore desired_size drift on node group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ this project adheres to the stability contract in
   `desired_size` as authoritative. Once the autoscaler moved the live count
   away from `var.node_desired`, every subsequent plan proposed resetting it
   back down, and applying that drains live nodes: reported in
-  [#50](https://github.com/n8n-io/terraform-aws-n8n/issues/50), an apply
+  [#50](https://github.com/n8n-io/terraform-aws-n8n/issues/50) on module
+  0.2.0, an apply
   during an HPA scale-up event reset `desired_size` from 6 to 3, draining 3
   nodes mid-rollout and evicting n8n pods. `scaling_config[0].desired_size`
   is now in the node group's `lifecycle.ignore_changes`, the standard pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ this project adheres to the stability contract in
 
 ### Fixed
 
+- `aws_eks_node_group.n8n` no longer fights the Cluster Autoscaler over
+  `desired_size`. The node group is tagged for autoscaler auto-discovery
+  (`k8s.io/cluster-autoscaler/enabled`), but Terraform still tracked
+  `desired_size` as authoritative. Once the autoscaler moved the live count
+  away from `var.node_desired`, every subsequent plan proposed resetting it
+  back down, and applying that drains live nodes: reported in
+  [#50](https://github.com/n8n-io/terraform-aws-n8n/issues/50), an apply
+  during an HPA scale-up event reset `desired_size` from 6 to 3, draining 3
+  nodes mid-rollout and evicting n8n pods. `scaling_config[0].desired_size`
+  is now in the node group's `lifecycle.ignore_changes`, the standard pattern
+  for autoscaler-managed node groups. `node_desired` now only sets the size at
+  creation; its description was updated to say so.
+
 - The module-managed Ingress routed only `/webhook` to the webhook processors.
   n8n disables five endpoint families on the main pods when
   `disableProductionWebhooksOnMainProcess` is set, which this module always

--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ No modules.
 | <a name="input_n8n_worker_memory_limit"></a> [n8n\_worker\_memory\_limit](#input\_n8n\_worker\_memory\_limit) | Memory limit for n8n worker pods (e.g. 2Gi, 4Gi) | `string` | `"2Gi"` | no |
 | <a name="input_n8n_worker_memory_request"></a> [n8n\_worker\_memory\_request](#input\_n8n\_worker\_memory\_request) | Memory request for n8n worker pods (e.g. 1Gi, 2Gi) | `string` | `"1Gi"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy n8n into | `string` | `"n8n"` | no |
-| <a name="input_node_desired"></a> [node\_desired](#input\_node\_desired) | Desired number of worker nodes at startup | `number` | `3` | no |
+| <a name="input_node_desired"></a> [node\_desired](#input\_node\_desired) | Initial number of worker nodes. Only applies at creation: the node group's desired\_size ignores changes afterward so the Cluster Autoscaler can own it without fighting plans/applies. | `number` | `3` | no |
 | <a name="input_node_instance_type"></a> [node\_instance\_type](#input\_node\_instance\_type) | EC2 instance type for EKS worker nodes. t3.xlarge (4 vCPU, 16GB) is the recommended minimum for multi-main — the 6 n8n pods (main × 2, worker × 2, webhook × 2) request ~3,600m CPU at minimum replicas, leaving t3.medium nodes with insufficient headroom for HPA to scale. | `string` | `"t3.xlarge"` | no |
 | <a name="input_node_max"></a> [node\_max](#input\_node\_max) | Maximum number of worker nodes | `number` | `6` | no |
 | <a name="input_node_min"></a> [node\_min](#input\_node\_min) | Minimum number of worker nodes | `number` | `3` | no |

--- a/eks.tf
+++ b/eks.tf
@@ -108,6 +108,13 @@ resource "aws_eks_node_group" "n8n" {
     aws_iam_role_policy_attachment.nodes_cni,
     aws_iam_role_policy_attachment.nodes_ecr,
   ]
+
+  # The Cluster Autoscaler owns desired_size after creation (see tags above).
+  # Without this, every plan after an autoscaler scaling event tries to reset
+  # desired_size back to var.node_desired, and applying that drains live nodes.
+  lifecycle {
+    ignore_changes = [scaling_config[0].desired_size]
+  }
 }
 
 # ── EKS Pod Identity Agent ────────────────────────────────────────────────────

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -85,6 +85,13 @@ run "defaults_produce_valid_plan" {
     error_message = "node_instance_type default should be t3.xlarge for multi-main workload"
   }
 
+  # Confirms desired_size still plans from var.node_desired on create. The
+  # lifecycle.ignore_changes = [scaling_config[0].desired_size] added for issue
+  # #50 only suppresses drift against *real* state once the Cluster Autoscaler
+  # has changed the live desired_size out-of-band — a mocked plan-time test has
+  # no prior state to diverge from, so it cannot exercise that behavior. It is
+  # verified by a live apply, a manual scale event (or CA-driven scale), and a
+  # follow-up `terraform plan` showing no changes to desired_size.
   assert {
     condition     = aws_eks_node_group.n8n.scaling_config[0].desired_size == 3
     error_message = "node_desired should default to 3 (multi-main minimum)"

--- a/variables.tf
+++ b/variables.tf
@@ -201,7 +201,7 @@ variable "node_instance_type" {
 }
 
 variable "node_desired" {
-  description = "Desired number of worker nodes at startup"
+  description = "Initial number of worker nodes. Only applies at creation: the node group's desired_size ignores changes afterward so the Cluster Autoscaler can own it without fighting plans/applies."
   type        = number
   default     = 3
 


### PR DESCRIPTION
## Summary

- The node group is tagged for Cluster Autoscaler auto-discovery, but Terraform still tracked `scaling_config.desired_size` as authoritative. Once the autoscaler moved the live count away from `var.node_desired`, every plan proposed resetting it back down, and applying that drains live nodes.
- Adds `scaling_config[0].desired_size` to `aws_eks_node_group.n8n`'s `lifecycle.ignore_changes`, the standard pattern for autoscaler-managed node groups.
- Updates `node_desired`'s description to clarify it only sets the size at creation.

Fixes #50

## Test plan

- [x] `terraform validate`
- [x] `terraform fmt -check`
- [x] `terraform test` (101 passed, 0 failed, including the existing `scaling_config` assertions in `tests/defaults.tftest.hcl`)
- [x] `terraform-docs .` regenerated `README.md`