### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to the stability contract in
 [README.md → Stability & versioning](./README.md#stability--versioning).
 
-## [Unreleased]
+## [0.3.0] - 2026-08-13
+
+Minor release per the [stability contract](./README.md#stability--versioning):
+the Terraform CLI floor raised to `>= 1.11` (see **Fixed**, below) is breaking
+for callers on an older CLI, and this range also refactors several resource
+addresses (absorbed by `moved` blocks, but a minor-boundary change under the
+contract regardless). Existing deployments upgrade with a no-op or in-place
+plan throughout, since every address change carries its own `moved` block and
+default changes that affect provisioning (e.g. `db_engine_version`) are
+guarded by `lifecycle.ignore_changes` on the resources that would otherwise
+drift. Pin this module to `~> 0.2.0` to stay on the previous floor and
+defaults, or retype your constraint to `~> 0.3.0` and read the upgrade notes
+under **Changed** and **Fixed**.
 
 ### Added
 
@@ -2047,6 +2059,37 @@ this project adheres to the stability contract in
   state, which defeats the reason this input exists. A typo surfaces only as a
   pod stuck in `CreateContainerConfigError`, not as a Terraform error.
 
+### Compatibility
+
+- **AWS provider:** `~> 6.0`.
+- **Helm provider:** `~> 3.0`.
+- **Kubernetes provider:** `~> 2.0`.
+- **Terraform CLI:** `>= 1.11` (raised from `>= 1.9`; see upgrade note under
+  **Fixed**).
+- **n8n Helm chart:** default `1.10.0`. Other chart versions can be selected
+  via `n8n_chart_version`.
+- **Kubernetes:** validated on EKS `1.35`.
+- **PostgreSQL:** validated on RDS `18.4` (raised from `16.9`; see upgrade
+  note under **Changed**).
+
+### Known limitations
+
+- On `create_eks = false` + `create_ingress = true`, `install_lbc = false` is
+  hard-rejected with no exception for an existing cluster that already runs a
+  healthy Load Balancer Controller. Documented as a known limitation rather
+  than fixed in this release; see
+  [`docs/customer-managed-infrastructure.md`](./docs/customer-managed-infrastructure.md).
+- Nodes loaded via `n8n_custom_extensions_path` register as `CUSTOM.<node>`
+  rather than `<npm-package>.<node>`, so workflows built against a
+  UI-installed copy of the same community package will not resolve. Suits new
+  deployments rather than migrating one that already uses community nodes.
+- `examples/customer-managed-cluster` and `examples/customer-managed-everything`
+  have no full-plan `terraform test` coverage: `data.aws_eks_cluster.existing`
+  cannot resolve to a known value under mocked providers once nested inside an
+  example's own `module "n8n"` call.
+- See [README.md → Out of scope](./README.md#out-of-scope) for what this
+  release explicitly does not cover.
+
 ## [0.2.0] - 2026-07-15
 
 Minor release per the [stability contract](./README.md#stability--versioning):
@@ -2227,6 +2270,7 @@ Initial release on the Terraform Registry as `n8n-io/n8n/aws`.
   block CI. Curated suppressions and a flip to hard-fail are tracked
   for v0.2.0.
 
-[Unreleased]: https://github.com/n8n-io/terraform-aws-n8n/compare/0.2.0...HEAD
+[Unreleased]: https://github.com/n8n-io/terraform-aws-n8n/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/n8n-io/terraform-aws-n8n/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/n8n-io/terraform-aws-n8n/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/n8n-io/terraform-aws-n8n/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Set exactly one of:
 ```hcl
 module "n8n" {
   source  = "n8n-io/n8n/aws"
-  version = "~> 0.2.0"
+  version = "~> 0.3.0"
 
   aws_region      = "us-east-1"
   cluster_name    = "n8n-cluster"
@@ -119,12 +119,12 @@ bug-fix changes.
 | `0.MINOR.PATCH` → `0.MINOR.PATCH+1` | Bug fixes, new optional inputs, new outputs, new resources whose absence wouldn't affect existing callers. No removed or renamed inputs/outputs. No changed defaults that move infra. No changed resource addresses. |
 | `0.MINOR` → `0.MINOR+1` | Anything else, including removed inputs, renamed inputs, default changes that force resource replacement, refactored resource addresses, and bumped provider version floors. Each such change is called out in [`CHANGELOG.md`](./CHANGELOG.md) with an upgrade note. |
 
-Pin with `version = "~> 0.2.0"` to auto-receive 0.2.x patches without
-accidentally crossing a 0.2 → 0.3 boundary. Note the three-component
-constraint: `~> 0.2.0` resolves to `>= 0.2.0, < 0.3.0`, whereas the
-two-component `~> 0.2` would resolve to `>= 0.2, < 1.0` and let you cross
+Pin with `version = "~> 0.3.0"` to auto-receive 0.3.x patches without
+accidentally crossing a 0.3 → 0.4 boundary. Note the three-component
+constraint: `~> 0.3.0` resolves to `>= 0.3.0, < 0.4.0`, whereas the
+two-component `~> 0.3` would resolve to `>= 0.3, < 1.0` and let you cross
 minor boundaries unintentionally. To upgrade across minor lines, retype
-the constraint (e.g. `version = "~> 0.3.0"`) and read the release notes.
+the constraint (e.g. `version = "~> 0.4.0"`) and read the release notes.
 
 This contract goes away at 1.0.0 in favor of standard SemVer.
 
@@ -154,7 +154,7 @@ See [docs/upgrading-n8n.md](docs/upgrading-n8n.md) for the procedure to safely b
 
 ## Out of scope
 
-v0.2.0 intentionally does not cover the following. Each item is
+v0.3.0 intentionally does not cover the following. Each item is
 documented here so that issues filed against them can be triaged
 quickly; several are candidates for future minor releases (see
 [`ROADMAP.md`](./ROADMAP.md)).


### PR DESCRIPTION
# 0.3.0 release

This PR cuts release 0.3.0 of `terraform-aws-n8n`, following the process
established in #21/#48 (release PR → merge commit → annotated tag on `main`).
Per the stability contract this is a **minor** release: the Terraform CLI
floor raised to `>= 1.11` (was `>= 1.9`) is breaking for callers on an older
CLI, and this range also refactors several resource addresses (all absorbed
by `moved` blocks).

## Scope

Everything merged to `main` since the `0.2.0` tag (19 first-parent commits), notably:

- **Breaking:** Terraform CLI floor raised to `>= 1.11` (was `>= 1.9`) — #89
- Customer-managed EKS (`create_eks = false`) plus a new `modules/controllers` submodule for advanced callers on an existing cluster — #89
- Redis high availability, transit encryption (TLS + AUTH), and a configurable reconnect budget — #75, #86
- IAM permissions-boundary support and curated/hard-failing checkov static analysis — #82, #83
- `db_engine_version` default bumped to `18.4` (was `16.9`), guarded by `lifecycle.ignore_changes` so existing instances are unaffected — #85
- Custom n8n images with baked-in community nodes (`n8n_image_repository`, `n8n_custom_extensions_path`, `n8n_extra_volumes`) — #71
- `redis_key_prefix` to namespace Redis keys for multiple deployments sharing one external Redis — #89
- n8n External Secrets support (workflow credentials) and `*_secret_ref` inputs for consuming caller-managed Kubernetes Secrets — #89
- `n8n_encryption_key` input for disaster-recovery key continuity — #89
- ALB ingress restriction (`alb_inbound_cidrs`, prefix lists) and `alb_ssl_policy` — #65, #78
- Execution data offload to S3 (`n8n_execution_data_storage_mode`) — #69
- Fixes: HPA/KEDA replica counts no longer collapse on `helm upgrade`, node group `desired_size` no longer fights the Cluster Autoscaler, webhook Ingress now routes all five endpoint families (not just `/webhook`), and 18 resource addresses gained `moved` blocks for the `create_eks`/submodule refactors — #68, #72, #73, #89

Full detail, upgrade notes, and known limitations are in `CHANGELOG.md` under `[0.3.0]`.

## Changes in this PR

- `CHANGELOG.md`: `Unreleased` → `[0.3.0] - 2026-08-13`, with an intro paragraph on the minor-boundary triggers, plus new `### Compatibility` and `### Known limitations` sections (mirroring the `[0.2.0]` entry's shape). Tag-comparison links updated (`[0.3.0]` added, `[Unreleased]` repointed).
- `README.md`: usage example pin, the "Pin with" three-component-constraint explainer, and the "Out of scope" line all bumped from 0.2.0 → 0.3.0.

## Pre-release verification (all green)

- `terraform fmt -check -recursive`
- `terraform validate` — module root + all 10 examples
- `terraform test` — module root (461 passed) + all 10 example suites (121 passed): 582 passed, 0 failed total
- `tflint` — module root + all 10 examples, no findings
- `terraform-docs --output-check .` — module root + all 10 examples, README not stale
- `checkov` not run locally: my install is 3.3.0, the pinned CI version is 3.3.9, and `tests/scripts/check-checkov.sh` deliberately refuses to run against a mismatched version. Leaving this to CI's pinned install.
- CI green on `main` prior to this branch

Note: two intermittent local test failures during this loop (one in the root suite, one in `examples/small`) turned out to be environment artifacts, not regressions — a stray `terraform test` re-init race on the first pass, and a leftover local `terraform.tfvars`/`.tfstate` from prior live-deployment testing in six of the example directories (gitignored, not part of the repo) overriding `n8n_image_tag`'s default. Both were isolated and the full suite reran clean; the local files were restored afterward.

## Release-day checklist (after review on this PR)

- [ ] Merge with a **merge commit** (not squash/rebase, per the #21 convention)
- [ ] Annotated tag `0.3.0` on the merge commit on `main` (no `v` prefix, matching `0.1.0`/`0.2.0`)
- [ ] Create the GitHub release from the tag
- [ ] Confirm the Terraform Registry picks up `0.3.0` for `n8n-io/n8n/aws`
- [ ] Delete the `release/0.3.0` branch