### PR TITLE
fix(examples): update large-tier values to load-tested measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,26 @@ this project adheres to the stability contract in
 
 ### Changed
 
+- **`examples/large` now carries the values load validation round 2 measured
+  on this deployment class**, replacing the reasoning that shipped with them.
+  `db_postgresdb_pool_size` 5 to 20: pool 5 was the exact value behind a
+  silent-503 storm in which pool acquisition backlogged, n8n's database
+  health-check ping (which shares the pool) timed out, and pods misdiagnosed a
+  healthy Aurora as dead. `redis_node_type` `cache.r6g.large` to `2xlarge`: a
+  throughput A/B measured a hard 869 req/s ceiling on `large` that lifted to
+  897-906 req/s with no other change. `n8n_worker_keda_max_replicas` 160 to
+  320: the endurance headline ran at 320 workers, and throughput at this tier
+  scales in pod count. `node_disk_size = 100`: the fleet-wide disk eviction
+  behind the new input happened on this deployment class. PgBouncer 2 to 4
+  replicas, so the client-connection budget (`MAX_CLIENT_CONN` 3,000 x 4)
+  stays above the ~9,200 connections the raised maxima can open. The 24-hour
+  pruning rationale is rewritten as a warning: hard deletion is hardcoded at
+  100 executions/s, so retention settings cannot bound table growth at this
+  tier. The example's README, `pgbouncer.tf` comments and test pin follow.
+  `examples/medium` gains the Redis upgrade trigger and the pruning caveat as
+  comments only; `examples/small` is untouched, since no evidence exists at
+  that scale. Examples only: no module input, output or resource changes.
+
 - **The module now sets `N8N_EDITOR_BASE_URL`** to `https://<n8n_domain>`,
   emitted next to `WEBHOOK_URL` in the chart's `config.extraEnv`. The name was
   already reserved in `local.n8n_managed_env_names` but never assigned, so

--- a/examples/large/README.md
+++ b/examples/large/README.md
@@ -11,10 +11,10 @@ Route 53 (alias A-record)
     └─► ALB (AWS LBC) ──► EKS (10–50 × m7i.4xlarge)
                                ├─► n8n main pods (HPA, min=6 / max=60)
                                ├─► n8n webhook processors (HPA, min=30 / max=80)
-                               └─► n8n workers (KEDA, min=20 / max=160)
-                                        ├─► PgBouncer (2 replicas, transaction mode)
+                               └─► n8n workers (KEDA, min=20 / max=320)
+                                        ├─► PgBouncer (4 replicas, transaction mode)
                                         │        └─► Aurora PostgreSQL (writer + reader)
-                                        └─► ElastiCache Redis cache.r6g.large
+                                        └─► ElastiCache Redis cache.r6g.2xlarge
 ```
 
 ## Key sizing decisions
@@ -23,18 +23,20 @@ Route 53 (alias A-record)
 |---|---|---|
 | Node type | m7i.4xlarge (16 vCPU, 64 GB) | x86_64 required with AL2023_x86_64_STANDARD AMI; Graviton requires separate AMI type |
 | Node count | desired=10, min=10, max=50 | Warm floor of 10; 50 max covers 2,400 req/s peaks |
+| Node disk | 100 GiB root volume (`node_disk_size`) | The EKS default of 20 GiB filled fleet-wide under image plus execution-data churn on this deployment class and evicted every pod on the node group; that incident is what motivated the module input |
 | VPC private subnets | 2× /20 (4,094 IPs each) | /24s exhausted by default VPC CNI warm-IP pools at 20+ large nodes |
 | VPC CNI tuning | WARM_ENI_TARGET=0, WARM_IP_TARGET=2 | Reduces pre-warmed IPs from ~2,400 to 20 across 10 nodes |
 | Database | Aurora PostgreSQL I/O-Optimized | Removes IOPS ceiling; 14,000–15,000 TPS sustained vs ~600 req/s ceiling on RDS gp3 |
 | Aurora instances | 1 writer + 1 reader | Automatic failover; reader offloads reporting queries |
-| PgBouncer | 2 replicas, transaction mode | 1,500 client connections at the pod ceilings (80 webhook + 160 worker + 60 main, pool_size=5); `MAX_CLIENT_CONN=3000` per replica, so a single surviving replica absorbs all of them; transaction mode confirmed compatible with n8n TypeORM |
-| Redis | cache.r6g.large | 77% peak memory at 856 req/s with no evictions or rejected connections |
+| PgBouncer | 4 replicas, transaction mode | ~9,200 potential client connections at the pod ceilings (80 webhook + 320 worker + 60 main, pool_size=20) against a 12,000 budget (`MAX_CLIENT_CONN=3000` x 4). Two replicas (6,000) would be oversubscribed, and exceeding `max_client_conn` queues new clients, recreating the pool-acquisition backlog the pool sizing exists to prevent. Transaction mode confirmed compatible with n8n TypeORM |
+| DB pool per pod | `db_postgresdb_pool_size = 20` | Shipped as 5 and measured failing under burst: pool acquisition backlogged to 33-54 pending per pod (2-14 s acquires), n8n's DB health-check ping races the same pool and times out, and the pod misdiagnoses a healthy database as dead, silently 503ing every request (91 of 160 webhook pods, roughly two thirds of requests, Aurora and PgBouncer idle). Pool 20 plus `DB_PING_TIMEOUT_MS=20000` eliminated it |
+| Redis | cache.r6g.2xlarge | Measured hard ceiling: 869 req/s on cache.r6g.large, 897-906 req/s on 2xlarge with no other change. Every execution crosses the Bull queue, so at this tier's target the large node is the bottleneck |
 | Main pods | min=6, max=60 | Mains serve the editor and REST API only, not webhooks or manual executions, so the ceiling tracks concurrent users rather than executions/day; 10× the module default, the same factor this tier scales the webhook ceiling by. Floor of 6 keeps warm editor/API capacity, since n8n pods take tens of seconds to boot |
 | Webhook pods | min=30, max=80 | 10 pods saturated at ~960 req/s; 30 pod floor handles 500 concurrent VUs cleanly |
-| Worker pods | min=20, max=160 | 856 req/s ÷ concurrency=40 = 22 workers at steady state; 160 max for 2,400 req/s burst |
-| Worker concurrency | 40 | Doubles throughput per pod vs 20; pool_size=5 is sufficient with PgBouncer |
+| Worker pods | min=20, max=320 | The 587 req/s endurance headline on the representative real workflow ran at 320 workers; throughput at this tier scales in worker pod count, not per-pod CPU. The previous ceiling of 160 was never observed reaching the tier's target on a real workload |
+| Worker concurrency | 40 | Doubles the queue slots per pod vs 20, halving the pod count needed for a given throughput |
 | Execution concurrency limit | 2,000 | Default 100 throttles workers before any infrastructure bottleneck |
-| Pruning | 24h / 5M records | 14-day retention at this throughput rapidly accumulates hundreds of millions of rows; autovacuum cannot sustain concurrent writes at that size |
+| Pruning | 24h / 5M records | These values set what the pruner is allowed to reclaim, but they cannot bound table growth at this tier: n8n's hard deletion runs at a hardcoded ceiling of 100 executions/s (~8.6M/day, leader-only), and this tier sustains multiples of that. Plan for net `execution_entity` growth at any sustained completion rate above ~100/s |
 | Webhook memory | 4 Gi limit / 1 Gi request | 2 Gi caused memory-pressure 503s under 500 VU load; 4 Gi halved failure rate |
 
 ## Estimated cost (us-east-1, on-demand)
@@ -45,11 +47,11 @@ Route 53 (alias A-record)
 | EKS nodes (50 × m7i.4xlarge, at max) | ~$29,434 |
 | Aurora writer db.r6g.8xlarge | ~$5,606 |
 | Aurora reader db.r6g.8xlarge | ~$5,606 |
-| ElastiCache cache.r6g.large | ~$121 |
+| ElastiCache cache.r6g.2xlarge | ~$480 |
 | EKS control plane | ~$73 |
 | NAT Gateways (2× HA) | ~$70 |
-| **Total (10 nodes steady-state)** | **~$17,300** |
-| **Total (50 nodes peak)** | **~$41,000** |
+| **Total (10 nodes steady-state)** | **~$17,700** |
+| **Total (50 nodes peak)** | **~$41,300** |
 
 1-year Reserved Instances reduce compute ~35%. If load is concentrated in business hours, KEDA/HPA autoscaling (rather than fixed min=desired) reduces average node spend by 30–40%.
 

--- a/examples/large/main.tf
+++ b/examples/large/main.tf
@@ -158,11 +158,13 @@ module "n8n" {
   # spare during a rollout on a tier where mains span only two AZs.
   #
   # Neither the node group nor PgBouncer is the constraint. Main pods alone at
-  # this ceiling request 72,000m and open 300 client connections at pool_size=5.
-  # With all three families at their ceilings at once, which is what the node
-  # group has to survive, it is 208,000m of the ~785,000m this node group can
-  # schedule (60 × 1,200m main, 160 × 700m worker, 80 × 300m webhook) and ~1,500
-  # client connections against a MAX_CLIENT_CONN of 3,000 per PgBouncer replica.
+  # this ceiling request 72,000m and open 1,200 client connections at
+  # pool_size=20. With all three families at their ceilings at once, which is
+  # what the node group has to survive, it is 320,000m of the ~785,000m this
+  # node group can schedule (60 x 1,200m main, 320 x 700m worker, 80 x 300m
+  # webhook) and ~9,200 client connections (460 pods x pool_size 20) against
+  # PgBouncer's 12,000 budget (MAX_CLIENT_CONN 3,000 x 4 replicas, sized in
+  # pgbouncer.tf to stay above this ceiling).
   n8n_main_hpa_min_replicas = 6
   n8n_main_hpa_max_replicas = 60
 

--- a/examples/large/main.tf
+++ b/examples/large/main.tf
@@ -115,14 +115,35 @@ module "n8n" {
   node_min           = 10
   node_max           = 50
 
+  # 100 GiB volumes: the module's default disk filled fleet-wide under n8n's
+  # image plus execution-data churn and evicted every pod on the node group
+  # (the incident behind the node_disk_size variable itself). This tier is
+  # the deployment class that eviction happened on.
+  node_disk_size = 100
+
   # ── Redis ─────────────────────────────────────────────────────────────────────
-  redis_node_type = "cache.r6g.large"
+  # Measured hard ceiling: the no-op webhook workload capped at 869 req/s on
+  # cache.r6g.large and reached 897-906 req/s on cache.r6g.2xlarge with no
+  # other change (round-2 T-B/T-C passes, 2026-08-24). Redis backs the Bull
+  # queue, so every execution crosses it; at this tier's throughput target
+  # the large node IS the bottleneck. If you downsize, 869 req/s is the
+  # measured trigger for moving back up.
+  redis_node_type = "cache.r6g.2xlarge"
 
   # ── DB pool per n8n pod ───────────────────────────────────────────────────────
-  # 5 TypeORM slots per pod. In transaction mode, PgBouncer queues connections
-  # for the ~1ms they are needed — pool of 5 handles concurrency=40 without
-  # timeouts. PgBouncer's own server-pool sizing lives in pgbouncer.tf.
-  db_postgresdb_pool_size = 5
+  # 20 TypeORM slots per pod. This value shipped as 5, defended as "PgBouncer
+  # queues connections for the ~1ms they are needed"; measured under burst,
+  # that assumption fails. Pool acquisition backlogs (33-54 requests pending
+  # per pod, acquire times of 2-14s), n8n's DB health-check ping races the
+  # SAME pool and times out, and the pod misdiagnoses the healthy database as
+  # dead, silently 503ing every request (91 of 160 webhook pods, roughly two
+  # thirds of all requests, with Aurora and PgBouncer both idle throughout).
+  # pool=20 plus DB_PING_TIMEOUT_MS=20000 eliminated the failure and was kept
+  # as standing config for the rest of the round. PgBouncer in transaction
+  # mode absorbs the upstream connection count; it does not remove the
+  # pod-local queue this pool governs. PgBouncer's own server-pool sizing
+  # lives in pgbouncer.tf.
+  db_postgresdb_pool_size = 20
 
   # ── Main pods ─────────────────────────────────────────────────────────────────
   # Mains carry neither webhooks (disableProductionWebhooksOnMainProcess) nor
@@ -156,18 +177,25 @@ module "n8n" {
 
   # ── Workers ───────────────────────────────────────────────────────────────────
   # concurrency=40: doubles throughput per pod vs 20, halves pod count needed.
-  # 856 req/s target ÷ concurrency=40 = 22 workers at steady state.
-  # Floor of 20 keeps the queue draining during idle periods.
+  # Floor of 20 keeps the queue draining during idle periods. Ceiling of 320:
+  # the round-2 endurance headline (587 req/s sustained on the representative
+  # real workflow) ran at 320 workers, and throughput at this tier scales in
+  # worker pod count, not per-pod CPU. The previous ceiling of 160 was never
+  # observed reaching this tier's target on a real workload.
   n8n_worker_keda_min_replicas = 20
-  n8n_worker_keda_max_replicas = 160
+  n8n_worker_keda_max_replicas = 320
   n8n_worker_concurrency       = 40
 
   # ── Execution settings ────────────────────────────────────────────────────────
   # Raise the hard concurrency cap from 100 to 2,000 — the default throttles
   # workers before any infrastructure bottleneck at this scale.
-  # 24-hour pruning is critical at this throughput: 14-day retention rapidly
-  # accumulates hundreds of millions of rows in execution_entity, and
-  # autovacuum cannot keep up with concurrent write load at that table size.
+  # WARNING: pruning settings cannot bound table growth at this tier. n8n's
+  # hard deletion runs at a hardcoded, non-configurable ceiling of 100
+  # executions/s (batchSize=100, rescheduled every 1 second, leader-only),
+  # which is ~8.6M deletions/day. This tier sustains multiples of that, so
+  # execution rows accumulate unboundedly whatever these two values say. They
+  # still matter (they set what the pruner is ALLOWED to reclaim), but plan
+  # for net table growth at any sustained completion rate above ~100/s.
   n8n_execution_concurrency_limit = 2000
   n8n_pruning_max_age             = 24
   n8n_pruning_max_count           = 5000000

--- a/examples/large/main.tf
+++ b/examples/large/main.tf
@@ -178,11 +178,12 @@ module "n8n" {
   n8n_webhook_memory_limit     = "4Gi"
 
   # ── Workers ───────────────────────────────────────────────────────────────────
-  # concurrency=40: doubles throughput per pod vs 20, halves pod count needed.
-  # Floor of 20 keeps the queue draining during idle periods. Ceiling of 320:
-  # the round-2 endurance headline (587 req/s sustained on the representative
-  # real workflow) ran at 320 workers, and throughput at this tier scales in
-  # worker pod count, not per-pod CPU. The previous ceiling of 160 was never
+  # concurrency=40: doubles the queue slots per pod vs 20, halving the pod
+  # count needed for a given throughput. Floor of 20 keeps the queue draining
+  # during idle periods. Ceiling of 320: the round-2 endurance headline (587
+  # req/s sustained on the representative real workflow) ran at 320 workers.
+  # Past that concurrency setting, throughput at this tier scales in worker
+  # pod count, not in per-pod CPU, so raise the ceiling before the requests. The previous ceiling of 160 was never
   # observed reaching this tier's target on a real workload.
   n8n_worker_keda_min_replicas = 20
   n8n_worker_keda_max_replicas = 320

--- a/examples/large/pgbouncer.tf
+++ b/examples/large/pgbouncer.tf
@@ -30,7 +30,9 @@
 #     max_client_conn queues new client connections, recreating exactly
 #     the pool-acquisition backlog the pool sizing exists to prevent.
 #     Four replicas is also the topology the sustained-load validation
-#     actually ran.
+#     actually ran. On the upstream leg, 4 x DEFAULT_POOL_SIZE 150 is at
+#     most 600 server connections to Aurora, well under the ~5,000
+#     max_connections of a db.r6g.8xlarge.
 #   - With required anti-affinity, later replicas stay Pending until
 #     enough nodes are Ready (typically <60s); the deployment as a whole
 #     is never blocked.

--- a/examples/large/pgbouncer.tf
+++ b/examples/large/pgbouncer.tf
@@ -17,15 +17,23 @@
 #     tags against current PgBouncer releases.
 #   - Transaction mode confirmed compatible with n8n's TypeORM (no prepared
 #     statements or LISTEN/NOTIFY that would force session mode).
-#   - Two replicas with REQUIRED pod anti-affinity guarantee placement on
-#     two distinct nodes (a `preferred` rule was observed losing the race
-#     against node-group startup ordering, co-locating both replicas on the
+#   - Four replicas with REQUIRED pod anti-affinity guarantee placement on
+#     four distinct nodes (a `preferred` rule was observed losing the race
+#     against node-group startup ordering, co-locating replicas on the
 #     first Ready node — a single-node failure would then have taken out
 #     all n8n DB traffic). A PodDisruptionBudget with min_available=1
-#     keeps at least one replica up during voluntary node drains.
-#   - With required anti-affinity, the second replica stays Pending until a
-#     second node is Ready (typically <60s); the deployment as a whole is
-#     never blocked.
+#     keeps replicas up during voluntary node drains. Four is also the
+#     client-connection budget: MAX_CLIENT_CONN=3000 x 4 = 12,000, sized
+#     for the fleet ceiling of ~9,200 (460 pods x pool_size 20; see the
+#     capacity arithmetic in main.tf's Main pods comment). Two replicas
+#     (6,000) would be oversubscribed at those maxima, and exceeding
+#     max_client_conn queues new client connections, recreating exactly
+#     the pool-acquisition backlog the pool sizing exists to prevent.
+#     Four replicas is also the topology the sustained-load validation
+#     actually ran.
+#   - With required anti-affinity, later replicas stay Pending until
+#     enough nodes are Ready (typically <60s); the deployment as a whole
+#     is never blocked.
 #   - n8n connects over plain TCP (in-cluster); PgBouncer terminates SSL on
 #     its upstream leg to Aurora.
 #   - AUTH_TYPE=plain stores the plaintext password in userlist.txt so
@@ -75,7 +83,7 @@ resource "kubernetes_deployment" "pgbouncer" {
   }
 
   spec {
-    replicas = 2
+    replicas = 4
 
     selector {
       match_labels = { app = "pgbouncer" }

--- a/examples/large/tests/defaults.tftest.hcl
+++ b/examples/large/tests/defaults.tftest.hcl
@@ -271,11 +271,18 @@ run "vpc_cni_addon_warm_ip_tuning" {
 # unguarded is this example's choice of value.
 #
 # Verify manually with a real `terraform plan` from this directory: the node
-# group shows disk_size = 100, the cache cluster node_type =
-# "cache.r6g.2xlarge", and the rendered helm values carry
-# DB_POSTGRESDB_POOL_SIZE = 20 and maxReplicaCount = 320. After apply,
+# group shows disk_size = 100 and the cache cluster node_type =
+# "cache.r6g.2xlarge" (confirmed against real providers with no state on
+# 2026-09-04). The helm values are `(known after apply)` in a fresh-create
+# plan even with real providers, because the same yamlencode also carries the
+# Aurora endpoint and the random encryption key, so DB_POSTGRESDB_POOL_SIZE
+# = 20 and maxReplicaCount = 320 only render in a plan against an existing
+# deployment's state, or after apply via
 # `kubectl get scaledobject -n n8n -o yaml` and
-# `kubectl get deploy n8n-main -n n8n -o yaml` show the last two.
+# `kubectl get deploy n8n-main -n n8n -o yaml`. What plan-time does guarantee
+# is that both arguments are accepted module inputs (`terraform validate`
+# rejects an unknown argument), and n8n.tf references each variable directly.
+
 
 # ── PgBouncer ────────────────────────────────────────────────────────────────
 # Required anti-affinity, four replicas, and the PDB together guarantee that

--- a/examples/large/tests/defaults.tftest.hcl
+++ b/examples/large/tests/defaults.tftest.hcl
@@ -267,9 +267,9 @@ run "pgbouncer_namespace_and_replicas" {
 
   assert {
     # The kubernetes provider returns replicas as a string per its schema, not
-    # an int — compare to "2" rather than 2.
-    condition     = kubernetes_deployment.pgbouncer.spec[0].replicas == "2"
-    error_message = "PgBouncer must run 2 replicas; a single replica is a single point of failure for all n8n DB traffic"
+    # an int — compare to "4" rather than 4.
+    condition     = kubernetes_deployment.pgbouncer.spec[0].replicas == "4"
+    error_message = "PgBouncer must run 4 replicas: fewer is a client-connection budget below the fleet ceiling (460 pods x pool_size 20 is about 9,200 potential connections against MAX_CLIENT_CONN 3,000 per replica), and exceeding max_client_conn queues new client connections, recreating the very pool-acquisition backlog the pool sizing exists to prevent"
   }
 }
 

--- a/examples/large/tests/defaults.tftest.hcl
+++ b/examples/large/tests/defaults.tftest.hcl
@@ -251,11 +251,14 @@ run "vpc_cni_addon_warm_ip_tuning" {
 }
 
 # ── PgBouncer ────────────────────────────────────────────────────────────────
-# Required anti-affinity, two replicas, and the PDB together guarantee that
-# no single-node failure or voluntary drain can take all n8n DB traffic down.
-# These were the live-validated fixes from PR #4; pinning them at plan time
-# means a future refactor can't silently regress to `preferred` anti-affinity
-# or a single replica.
+# Required anti-affinity, four replicas, and the PDB together guarantee that
+# no single-node failure or voluntary drain can take all n8n DB traffic down,
+# and that the client-connection budget stays above the fleet ceiling (see
+# the replica assertion's message). Anti-affinity and the PDB were the
+# live-validated fixes from PR #4; the replica count was raised from two
+# during load validation. Pinning all of it at plan time means a future
+# refactor can't silently regress to `preferred` anti-affinity or an
+# undersized replica count.
 
 run "pgbouncer_namespace_and_replicas" {
   command = plan

--- a/examples/large/tests/defaults.tftest.hcl
+++ b/examples/large/tests/defaults.tftest.hcl
@@ -274,9 +274,12 @@ run "vpc_cni_addon_warm_ip_tuning" {
 # group shows disk_size = 100 and the cache cluster node_type =
 # "cache.r6g.2xlarge" (confirmed against real providers with no state on
 # 2026-09-04). The helm values are `(known after apply)` in a fresh-create
-# plan even with real providers, because the same yamlencode also carries the
-# Aurora endpoint and the random encryption key, so DB_POSTGRESDB_POOL_SIZE
-# = 20 and maxReplicaCount = 320 only render in a plan against an existing
+# plan even with real providers, because the same yamlencode also carries
+# attributes the module computes at apply time, such as the ElastiCache node
+# address behind local.redis_host (n8n.tf, the queue host and the KEDA
+# trigger address) and aws_iam_role.s3.arn for Pod Identity. One unknown
+# makes the whole string unknown, so DB_POSTGRESDB_POOL_SIZE = 20 and
+# maxReplicaCount = 320 only render in a plan against an existing
 # deployment's state, or after apply via
 # `kubectl get scaledobject -n n8n -o yaml` and
 # `kubectl get deploy n8n-main -n n8n -o yaml`. What plan-time does guarantee

--- a/examples/large/tests/defaults.tftest.hcl
+++ b/examples/large/tests/defaults.tftest.hcl
@@ -250,6 +250,33 @@ run "vpc_cni_addon_warm_ip_tuning" {
   }
 }
 
+# ── Load-validated module inputs ──────────────────────────────────────────────
+# main.tf carries five values that load validation round 2 measured on this
+# deployment class (see the comments beside each): node_disk_size = 100,
+# redis_node_type = "cache.r6g.2xlarge", db_postgresdb_pool_size = 20,
+# n8n_worker_keda_max_replicas = 320, and four PgBouncer replicas. Only the
+# PgBouncer count is pinned at plan time (next section), because it is a
+# resource this configuration creates itself.
+#
+# The other four cannot be asserted here. A run block can only reference the
+# root module's resources, variables and outputs; the module's resources
+# (module.n8n.aws_eks_node_group.n8n, module.n8n.aws_elasticache_cluster.n8n)
+# are "Unsupported attribute" from a test in this directory, the module exposes
+# no output carrying disk_size or node_type, and the values are literals in the
+# module block rather than example variables. The pool size and the KEDA
+# ceiling additionally live only inside the module's helm_release values, which
+# are deferred under the mock providers (see "Known mock provider limitations"
+# in AGENTS.md). The module's own suite pins the node_disk_size and
+# redis_node_type wiring (tests/defaults.tftest.hcl at the repo root); what is
+# unguarded is this example's choice of value.
+#
+# Verify manually with a real `terraform plan` from this directory: the node
+# group shows disk_size = 100, the cache cluster node_type =
+# "cache.r6g.2xlarge", and the rendered helm values carry
+# DB_POSTGRESDB_POOL_SIZE = 20 and maxReplicaCount = 320. After apply,
+# `kubectl get scaledobject -n n8n -o yaml` and
+# `kubectl get deploy n8n-main -n n8n -o yaml` show the last two.
+
 # ── PgBouncer ────────────────────────────────────────────────────────────────
 # Required anti-affinity, four replicas, and the PDB together guarantee that
 # no single-node failure or voluntary drain can take all n8n DB traffic down,

--- a/examples/medium/README.md
+++ b/examples/medium/README.md
@@ -27,7 +27,7 @@ Route 53 (alias A-record)
 | Webhook pods | min=5, max=50 | Floor of 5 is warm; 50 ceiling raises both the floor and the ceiling over the module default of 2/8 |
 | Worker pods | min=5, max=40 | Queue-driven via KEDA; floor ensures fast queue drain at any time |
 | Worker concurrency | 20 | Doubles throughput per pod vs default; pool_size=10 matches |
-| Pruning | 7 days / 500k records | Keeps execution_entity at manageable size without losing debug history |
+| Pruning | 7 days / 500k records | Keeps execution_entity at manageable size without losing debug history. Caveat: n8n's hard deletion is hardcoded at 100 executions/s (~8.6M/day, leader-only), so the retention math stops holding as sustained completion rates approach 100/s; see the large example for the mechanism |
 | Webhook memory | 2 Gi limit | 1 Gi limit is tight under sustained concurrent webhook load |
 
 ## Estimated cost (us-east-1, on-demand)

--- a/examples/medium/main.tf
+++ b/examples/medium/main.tf
@@ -96,6 +96,11 @@ module "n8n" {
   db_allocated_storage = 200
 
   # ── Redis ─────────────────────────────────────────────────────────────────────
+  # Kept at large for this tier. Measured upgrade trigger: the no-op webhook
+  # workload capped at 869 req/s on cache.r6g.large and reached 897-906 req/s
+  # on cache.r6g.2xlarge (round-2 T-B/T-C passes). If this tier's sustained
+  # throughput approaches that figure, move Redis up a size before tuning
+  # anything else.
   redis_node_type = "cache.r6g.large"
 
   # ── Main pods ─────────────────────────────────────────────────────────────────
@@ -139,7 +144,10 @@ module "n8n" {
   # ── Execution settings ────────────────────────────────────────────────────────
   # Concurrency limit of 200 gives 2× headroom over the worker floor × concurrency.
   # 7-day pruning keeps the execution_entity table at a manageable size without
-  # losing useful debugging history.
+  # losing useful debugging history. Caveat for sustained high rates: n8n's
+  # hard deletion is hardcoded at a 100 executions/s ceiling (~8.6M/day,
+  # leader-only), so retention math stops holding as sustained completion
+  # rates approach 100/s; see the large example's warning for the mechanism.
   n8n_execution_concurrency_limit = 200
   n8n_pruning_max_age             = 168
   n8n_pruning_max_count           = 500000


### PR DESCRIPTION
Stacked on #94 (`node_disk_size`, which the large example now exercises); retarget to main when #94 merges.

## What

Load validation round 2 ran on exactly this deployment class, and its measurements contradict two shipped `examples/large` values and one comment:

| Change | Evidence |
|---|---|
| `db_postgresdb_pool_size` 5 to 20 | 5 is the exact value behind the measured silent-503 storm: pool acquisition backlogs to 33-54 pending/pod (2-14s acquires), the DB health-check ping races the same pool, and the pod misdiagnoses a healthy database as dead, silently 503ing everything (91 of 160 pods, ~2/3 of requests, Aurora and PgBouncer both idle). pool=20 kept as standing config |
| `redis_node_type` large to 2xlarge | Measured throughput A/B: 869 req/s hard ceiling on `large`, 897-906 req/s after the resize with no other change |
| 24h-pruning comment rewritten as a warning | Hard deletion is hardcoded at 100 executions/s (~8.6M/day, leader-only); this tier sustains multiples of that, so rows accumulate regardless of these tfvars |
| `n8n_worker_keda_max_replicas` 160 to 320 | The 587 req/s endurance headline ran at 320 workers; throughput scales in pod count, not per-pod CPU |
| `node_disk_size = 100` | The fleet-wide disk eviction behind #94 happened on this deployment class; the flagship example should exercise the variable it motivated |
| PgBouncer 2 to 4 replicas (review finding) | At the new maxima, 460 pods x pool 20 is ~9,200 potential client connections against the shipped 6,000 budget; 4 replicas gives 12,000 and matches the topology the validation actually ran |

`examples/medium`: comments only (the measured Redis upgrade trigger, the pruning caveat). `examples/small`: untouched, no evidence exists at that scale and this series does not invent tunings.

## Deliberate omissions

- The Redis recommendation cites the throughput A/B only; a Redis CPU band previously attributed to the 869 baseline did not survive re-analysis and is deliberately not part of the evidence here.
- The pool comment pairs pool=20 with `DB_PING_TIMEOUT_MS=20000` (both were standing config); the default for that lives in #101.
- The webhook-tier scheduled-restart opt-in for this example intentionally ships with the restart feature's own PR, not here.

Gates: terraform fmt, terraform validate in the changed examples (medium, large).

Note: branch history was rewritten once to reword the first commit's message; content is unchanged apart from the PgBouncer sizing commit responding to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)