### PR TITLE
fix: set N8N_EDITOR_BASE_URL so the OAuth2 credential callback lands on the editor host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,23 @@ this project adheres to the stability contract in
 
 ### Changed
 
+- **The module now sets `N8N_EDITOR_BASE_URL`** to `https://<n8n_domain>`,
+  emitted next to `WEBHOOK_URL` in the chart's `config.extraEnv`. The name was
+  already reserved in `local.n8n_managed_env_names` but never assigned, so
+  neither the module nor an operator (through `n8n_extra_env`, which rejects
+  reserved names) could set it, and n8n fell back to `WEBHOOK_URL` when
+  building the editor's base URL — including the OAuth2 credential callback.
+  Deployments where `n8n_webhook_url` names a different host than `n8n_domain`
+  previously advertised that callback on the webhook host, where it 404s: a
+  split ingress routes only the webhook prefixes there, and the webhook
+  processors serve no `/rest` routes even when reached. It now resolves to
+  `https://<n8n_domain>/rest/oauth2-credential/callback`.
+
+  **Upgrade note.** If `n8n_webhook_url` points at a different host than
+  `n8n_domain`, update the redirect URI registered with any OAuth2 provider to
+  the `n8n_domain` form above. Every other configuration renders the value n8n
+  already resolved to, so nothing changes there.
+
 - `db_postgresdb_pool_size` is now documented as a lazy per-process maximum,
   not as one connection per concurrent workflow or request. Size it from
   measured concurrent database operations and pool-wait time, then verify that

--- a/n8n.tf
+++ b/n8n.tf
@@ -568,6 +568,29 @@ resource "helm_release" "n8n" {
           { name = "N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS", value = "true" },
           # Override the internally computed http://host:5678 URL so webhooks show the correct HTTPS address.
           { name = "WEBHOOK_URL", value = coalesce(var.n8n_webhook_url, "https://${local.n8n_domain}") },
+          # The editor's own base URL, and what n8n builds absolute non-webhook
+          # URLs from: UrlService.getInstanceBaseUrl() prefers
+          # N8N_EDITOR_BASE_URL and falls back to WEBHOOK_URL when it is unset.
+          # Above all it forms the OAuth2 credential redirect URI,
+          # <editor base>/rest/oauth2-credential/callback.
+          #
+          # Unset until now, which is harmless only while the two URLs agree.
+          # On a split hostname (n8n_webhook_url naming a second host, as
+          # examples/split-ingress does) the fallback labels the editor with
+          # the webhook hostname, and that callback 404s twice over: a split
+          # ingress routes only the webhook prefixes there, and the webhook
+          # processors serve no /rest routes even when reached. Webhook
+          # delivery keeps working throughout, which points the search at the
+          # wrong half. The chart cannot supply it either: it derives this from
+          # its own ingress host or from webhook.url, and this module sets
+          # neither (docs/helm-chart-coverage.md), so nothing emits it at all.
+          #
+          # n8n_domain rather than the webhook URL because n8n_domain is
+          # canonical: it is the name the editor is served on, what N8N_HOST
+          # already carries, and what n8n_additional_domains is defined
+          # against. Deployments where the two agree render the value n8n
+          # already resolves to today, so only a split hostname sees a change.
+          { name = "N8N_EDITOR_BASE_URL", value = "https://${local.n8n_domain}" },
           { name = "N8N_RUNNERS_TASK_REQUEST_TIMEOUT", value = tostring(var.n8n_task_runner_request_timeout) },
           # Keeps ElastiCache from dropping idle Redis subscriber connections under sustained load.
           # Without this, Bull detects dropped connections, emits queue errors, and pods crash.


### PR DESCRIPTION
# fix: set `N8N_EDITOR_BASE_URL` so the OAuth2 credential callback lands on the editor host

Split out of #93 at @buddy-n8n's request ([comment](https://github.com/n8n-io/terraform-aws-n8n/pull/93#issuecomment-5502996058)). That PR's `/rest/projects` routing is parked in draft pending Agents' Enterprise self-hosted readiness; this half is unrelated to Agents and ships on its own.

## The problem

`N8N_EDITOR_BASE_URL` was reserved in `local.n8n_managed_env_names` ([locals.tf:575](https://github.com/n8n-io/terraform-aws-n8n/blob/main/locals.tf#L575)) but never assigned. Because the name is reserved, `n8n_extra_env`'s validation rejects it too ([variables.tf:2758](https://github.com/n8n-io/terraform-aws-n8n/blob/main/variables.tf#L2758)), so the module neither sets the value nor lets an operator set it. There is no workaround through this module today.

n8n's `UrlService.getInstanceBaseUrl()` prefers `N8N_EDITOR_BASE_URL` and falls back to `WEBHOOK_URL` when it is unset. That base URL is what the OAuth2 credential redirect URI is built from — `<editor base>/rest/oauth2-credential/callback` — a normal credential connection, nothing to do with Agents or any preview feature.

The fallback is harmless only while the two URLs agree. On a split hostname (`n8n_webhook_url` naming a second host) it labels the editor with the webhook hostname, and the callback 404s twice over: a split ingress routes only the webhook prefixes to that host, and the webhook processors register no `/rest` routes even when reached. Webhook delivery keeps working the whole time, which sends the search after the wrong half.

The chart cannot supply the value either — it derives it from its own ingress host or from `webhook.url`, and this module sets neither (`docs/helm-chart-coverage.md`), so nothing emits it at all.

## The change

One hunk in `n8n.tf`: `N8N_EDITOR_BASE_URL = "https://${local.n8n_domain}"`, emitted next to `WEBHOOK_URL` in `config.extraEnv`.

`n8n_domain` rather than the webhook URL because it is the canonical name: it is the host the editor is served on, what `N8N_HOST` already carries, and what `n8n_additional_domains` is defined against. No gating and no override input — as discussed on #93, `https://<n8n_domain>` is correct in every configuration this module can express, so gating would only preserve n8n's wrong fallback for single-host deployments.

**Set in `config.extraEnv` only, not in `kubernetes_secret.n8n`.** `WEBHOOK_URL` appears in both today, but the chart's `coreSecretsEnv` helper reads exactly four hardcoded keys from `secretRefs.existingSecret` (`N8N_ENCRYPTION_KEY`, `N8N_HOST`, `N8N_PORT`, `N8N_PROTOCOL`), so a fifth key there would never be read, and it would quietly widen the contract documented for `n8n_encryption_key_secret_ref`. Say the word if you want it mirrored anyway for symmetry.

## Behaviour change

Anyone running `create_ingress = true` *and* an `n8n_webhook_url` pointing at a host other than `n8n_domain` currently gets an instance base URL of the webhook URL, and after this change gets `n8n_domain`. That is the correct value, but it moves the advertised OAuth2 redirect URI, which may already be registered with a provider. Single-host deployments — every other configuration — render exactly what n8n resolves to today.

Filed under `[Unreleased] / Changed` in `CHANGELOG.md` with that migration note, per the framing agreed on #93.

## Tests

No new assert. `helm_release.n8n.values` is unknown at plan time (the note at the top of `tests/defaults.tftest.hcl`, the same limitation the KEDA and OTEL sections work around) and locals are not addressable from `terraform test`. The seam would be an `n8n_oauth_callback_url` output built from the same expression, which is a new public output — out of scope here, happy to add it if you want the coverage.

`terraform fmt -recursive`, `terraform validate` and the root `terraform test` suite are clean on this branch. Live verification of the rendered env var on an EKS deployment is in [#93](https://github.com/n8n-io/terraform-aws-n8n/pull/93#issuecomment-5394075683): `N8N_EDITOR_BASE_URL` rendered as `https://<domain>` on mains and webhook processors, with `getInstanceBaseUrl()` no longer falling back to the webhook host.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/terraform-aws-n8n/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

