### PR TITLE
chore: update CONTRIBUTORS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for everything in the repo, unless a later match takes precedence.
-* @buddy-n8n @jrx @maspio
+* @buddy-n8n @jrx

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Contributors to terraform-aws-n8n, in order of first contribution:
 - Marcus (@maspio): contributor
 - Davesh (@devd-s): contributor (PR #46)
 - Raunaq (@RaunaqDavidNath): contributor (PR #112)
+- Ku-bonmoo (@m161awm2): contributor (PR #121)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,5 +2,6 @@ Contributors to terraform-aws-n8n, in order of first contribution:
 
 - Buddy (@buddy-n8n): maintainer
 - Jan (@jrx): maintainer
-- Marcus (@maspio): maintainer
+- Marcus (@maspio): contributor
 - Davesh (@devd-s): contributor (PR #46)
+- Raunaq (@RaunaqDavidNath): contributor (PR #112)


### PR DESCRIPTION
- Adds Raunaq (@RaunaqDavidNath) as a contributor, for #112 (`N8N_EDITOR_BASE_URL` fix).
- Adds Ku-bonmoo (@m161awm2) as a contributor, for #121 (`N8N_WEBHOOK_URL` fix, closes #116).
- Reclassifies Marcus (@maspio) from maintainer to contributor.
- Removes `@maspio` from `.github/CODEOWNERS` default owners, to match the reclassification.