### PR TITLE
feat: add credential overwrite secret reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,7 @@ conventions](https://developer.hashicorp.com/terraform/language/modules/develop/
   | `HPA: main pods` / `HPA: webhook processor pods` | CPU-based autoscaling |
   | `Observability` | Metrics/telemetry toggles |
   | `Community packages` | Custom-node loading, OTEL export, log streaming, the `n8n_extra_env` escape hatch |
+  | `Credential overwrites` | Caller-managed Kubernetes Secret reference for file-based credential overwrites |
   | `External Secrets` | External Secrets Operator integration |
   | `KEDA: worker pods` | Queue-depth autoscaling |
   | `Pod DNS` | Pod-level DNS settings (`n8n_dns_config`) to work around Kubernetes' `ndots:5` search-path amplification |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ this project adheres to the stability contract in
 
 ### Added
 
+- `n8n_credentials_overwrite_secret_ref`: mounts one key from a
+  caller-managed Kubernetes Secret read-only on main, worker, and webhook
+  processor pods and points `CREDENTIALS_OVERWRITE_DATA_FILE` at it. The module
+  accepts only the Secret name and key, so the credential overwrite JSON does
+  not enter its Helm values or managed resources. The input defaults to `null`,
+  preserving existing behavior.
+
+  When set, plan-time validation rejects `CREDENTIALS_OVERWRITE_DATA` and
+  `CREDENTIALS_OVERWRITE_DATA_FILE` in `n8n_extra_env`, the managed
+  `credentials-overwrite` volume name in `n8n_extra_volumes`, and the managed
+  `/etc/n8n/credentials-overwrite` path in `n8n_extra_volume_mounts`. These
+  names remain available through the escape hatches while the new input is
+  null, preserving existing configurations.
+
+  n8n reads overwrite data at startup. Rotating the caller-managed Secret does
+  not roll pods because the module deliberately does not read or hash the
+  payload. Restart the `n8n-main`, `n8n-worker`, and
+  `n8n-webhook-processor` deployments manually after rotation.
+
 - `node_disk_size`: root EBS volume size in GiB for the EKS worker nodes.
   Defaults to `null`, which keeps the EKS managed-node-group default of 20
   GiB, so this is additive and no existing deployment changes.

--- a/README.md
+++ b/README.md
@@ -1742,7 +1742,7 @@ kubectl rollout restart \
   deployment/n8n-main \
   deployment/n8n-worker \
   deployment/n8n-webhook-processor \
-  -n n8n
+  -n <namespace>
 ```
 
 `CREDENTIALS_OVERWRITE_PERSISTENCE` is separate and remains out of scope.

--- a/README.md
+++ b/README.md
@@ -1691,6 +1691,61 @@ Terraform state and the pod environment in plaintext — restrict access
 accordingly. Setting `n8n_log_streaming_managed_by_env` back to `false`
 keeps the last applied destinations but restores UI write access.
 
+## Credential overwrites
+
+n8n [credential overwrites](https://docs.n8n.io/administer/manage-credentials/credential-overwrites/)
+let operators preconfigure shared credential fields and hide those fields from
+users. Supply the JSON through a caller-managed Kubernetes Secret:
+
+```hcl
+resource "kubernetes_secret_v1" "credentials_overwrite" {
+  metadata {
+    name      = "n8n-credentials-overwrite"
+    namespace = module.n8n.namespace
+  }
+
+  data = {
+    "credentials-overwrite.json" = var.credentials_overwrite_json
+  }
+}
+
+module "n8n" {
+  # ...other inputs...
+
+  n8n_credentials_overwrite_secret_ref = {
+    name = kubernetes_secret_v1.credentials_overwrite.metadata[0].name
+    # key defaults to "credentials-overwrite.json"
+  }
+}
+```
+
+The module mounts only the selected key read-only at
+`/etc/n8n/credentials-overwrite/<key>` on main, worker, and webhook-processor
+pods, then sets `CREDENTIALS_OVERWRITE_DATA_FILE` to that file. Passing the
+Secret resource's name attribute also makes the Helm release depend on the
+Secret, so a single apply creates them in the required order.
+
+The module accepts the Secret name and key, not the JSON. The payload therefore
+does not enter this module's Helm values or managed resources. If the caller
+creates the Secret with Terraform as above, the payload can still be stored in
+the caller's root state.
+
+n8n reads the file at startup. Updating the Secret does not restart any pods,
+and the module cannot calculate a rollout checksum without reading the payload
+back into state. Restart all three deployments after every rotation:
+
+```bash
+kubectl rollout restart \
+  deployment/n8n-main \
+  deployment/n8n-worker \
+  deployment/n8n-webhook-processor \
+  -n n8n
+```
+
+`CREDENTIALS_OVERWRITE_PERSISTENCE` is separate and remains out of scope.
+Persistence applies to overwrites submitted through n8n's HTTP endpoint and can
+supersede static file data.
+
 ## External Secrets (Enterprise)
 
 n8n's [External Secrets](https://docs.n8n.io/administer/manage-credentials/use-external-secret-stores)
@@ -1984,6 +2039,7 @@ doing at this node count, but neither removes the fivefold waste at source.
 | <a name="input_n8n_community_packages_registry"></a> [n8n\_community\_packages\_registry](#input\_n8n\_community\_packages\_registry) | npm registry community packages are installed from (e.g. <https://npm.internal.example.com>). Maps to N8N\_COMMUNITY\_PACKAGES\_REGISTRY, which n8n gates behind a specific licensed feature rather than a license key alone: any value other than <https://registry.npmjs.org> makes installs throw FeatureNotLicensedError unless the instance is entitled to COMMUNITY\_NODES\_CUSTOM\_REGISTRY (`getNpmRegistry` in community-packages.service.ts). Confirm that entitlement before setting this, since an unentitled instance breaks community-package installs instead of falling back to the public registry. Point this at a private mirror to install community nodes from an internal registry instead of the public npm one, e.g. when egress to registry.npmjs.org is blocked or packages are vendored. n8n defaults to <https://registry.npmjs.org>; when this is null (the default) the env var is omitted entirely so n8n's own default applies. A mirror that requires authentication also needs N8N\_COMMUNITY\_PACKAGES\_AUTH\_TOKEN, which this module does not manage; pass it via n8n\_extra\_env, keeping in mind that n8n\_extra\_env values are stored in plaintext in the Helm release and Terraform state. Baking packages into a custom image via n8n\_image\_repository avoids registry access at pod start entirely. | `string` | `null` | no |
 | <a name="input_n8n_compression_max_decompressed_size_bytes"></a> [n8n\_compression\_max\_decompressed\_size\_bytes](#input\_n8n\_compression\_max\_decompressed\_size\_bytes) | Largest decompressed payload the Compression node will produce, in bytes. Maps to N8N\_COMPRESSION\_NODE\_MAX\_DECOMPRESSED\_SIZE\_BYTES. Null (the default) omits the env var so n8n's own default applies, which is currently 2 GiB (2147483648) and which n8n has announced will drop to 256 MiB (268435456) in a future version. This is a zip-bomb limit, so the reduction is a hardening rather than a regression; set this only if workflows genuinely decompress archives larger than n8n's default allows, and set it to the value those workflows need rather than to the old default. | `number` | `null` | no |
 | <a name="input_n8n_compression_max_zip_entries"></a> [n8n\_compression\_max\_zip\_entries](#input\_n8n\_compression\_max\_zip\_entries) | Largest number of entries the Compression node will extract from one archive. Maps to N8N\_COMPRESSION\_NODE\_MAX\_ZIP\_ENTRIES. Null (the default) omits the env var so n8n's own default applies, which is currently 5000 and which n8n has announced will drop to 1000 in a future version. Like n8n\_compression\_max\_decompressed\_size\_bytes this is a zip-bomb limit, so the reduction hardens rather than breaks; set it only for workflows that genuinely process archives with more entries than n8n's default allows. | `number` | `null` | no |
+| <a name="input_n8n_credentials_overwrite_secret_ref"></a> [n8n\_credentials\_overwrite\_secret\_ref](#input\_n8n\_credentials\_overwrite\_secret\_ref) | Existing Kubernetes Secret containing n8n credential overwrite JSON. The<br/>module mounts only the selected key, read-only, at<br/>/etc/n8n/credentials-overwrite/<key> on main, worker, and webhook-processor<br/>pods and sets CREDENTIALS\_OVERWRITE\_DATA\_FILE to that path. name is the<br/>Secret's name in var.namespace; key defaults to<br/>"credentials-overwrite.json". The module accepts only this reference and<br/>never reads the JSON, so the payload does not enter this module's Helm values<br/>or managed resources. If Terraform creates the Secret, its payload can still<br/>enter the caller's state.<br/><br/>n8n reads the file at startup. Updating the caller-managed Secret does not<br/>roll pods, and the module cannot add a content checksum without reading the<br/>payload into state. After each rotation, manually restart n8n-main,<br/>n8n-worker, and n8n-webhook-processor. CREDENTIALS\_OVERWRITE\_PERSISTENCE is<br/>intentionally outside this file-based feature.<br/><br/>When this input is set, n8n\_extra\_env may not set<br/>CREDENTIALS\_OVERWRITE\_DATA or CREDENTIALS\_OVERWRITE\_DATA\_FILE,<br/>n8n\_extra\_volumes may not use the reserved name "credentials-overwrite",<br/>and n8n\_extra\_volume\_mounts may not use the reserved mount path<br/>"/etc/n8n/credentials-overwrite". Null preserves the escape-hatch behavior<br/>and rendered Helm values from before this input existed. | <pre>object({<br/>    name = string<br/>    key  = optional(string, "credentials-overwrite.json")<br/>  })</pre> | `null` | no |
 | <a name="input_n8n_custom_extensions_path"></a> [n8n\_custom\_extensions\_path](#input\_n8n\_custom\_extensions\_path) | Absolute path inside the n8n container that n8n scans for custom nodes at startup (e.g. "/opt/n8n-nodes"). Maps to N8N\_CUSTOM\_EXTENSIONS, and is set on every pod type (main, worker, webhook processor). This is the supported way to ship nodes baked into a custom image: since n8n 1.0 the loader no longer picks up nodes from the image's global node\_modules, so a plain npm install into the image is never seen (n8n v10 migration guide, and packages/cli/src/load-nodes-and-credentials.ts). Something has to put files at this path, so either set n8n\_image\_repository to an image that baked them in, or mount a volume that carries them with n8n\_extra\_volumes and n8n\_extra\_volume\_mounts; a path with neither behind it warns at plan time. The path must be outside /home/node/.n8n, which the chart mounts over on main pods (see the validation below). Two caveats that no Terraform input can fix. First, nodes loaded this way are registered under the package name CUSTOM, so a node whose type was n8n-nodes-example.myNode when installed from npm becomes CUSTOM.myNode, and existing workflows referencing the npm-qualified type will not resolve. Second, only one directory is exposed even though n8n accepts a semicolon-separated list, because every custom directory is registered under the same CUSTOM key and each one overwrites the last, so all but the final directory are silently dropped. Leave null (the default) to omit the env var entirely. | `string` | `null` | no |
 | <a name="input_n8n_dns_config"></a> [n8n\_dns\_config](#input\_n8n\_dns\_config) | Pod-level DNS settings applied to the main, worker and webhook-processor pods<br/>(the chart's top-level `dnsConfig`, rendered into all three pod specs).<br/>Defaults to null, which omits the block entirely and leaves Kubernetes'<br/>defaults in place, so this is a no-op unless set.<br/><br/>THE REASON THIS EXISTS: Kubernetes injects `options ndots:5` plus four search<br/>domains into every pod. A name with FEWER than 5 dots is tried against every<br/>search domain BEFORE being tried as written. Every AWS endpoint n8n talks to<br/>that has 4 dots or fewer therefore costs FIVE DNS queries, four of them<br/>guaranteed NXDOMAIN. Measured on a 246-pod deployment at roughly 670 req/s:<br/>12,794 DNS queries/s sustained, peaking at 15,098 (22.5 per HTTP request),<br/>of which 80.0% were NXDOMAIN, which is exactly the predicted 4-in-5. That<br/>volume saturated the cluster's two CoreDNS replicas and produced<br/>`getaddrinfo EAI_AGAIN` on S3 writes, surfacing to callers as HTTP 500s.<br/><br/>Which endpoints are affected depends only on their dot count:<br/>  s3.<region>.amazonaws.com bucket endpoints   4 dots  -> amplified 5x<br/>  <svc>.<ns>.svc.cluster.local                 4 dots  -> amplified 5x<br/>  RDS/Aurora writer endpoints                  5 dots  -> not amplified<br/>  ElastiCache endpoints                        6 dots  -> not amplified<br/><br/>The standard remedy is `ndots: 1`, which makes any name containing at least<br/>one dot resolve directly and cuts DNS volume roughly 5x. It is safe here<br/>because this module addresses every in-cluster dependency by FQDN already;<br/>bare single-label names (0 dots) still use the search path unchanged:<br/><br/>  n8n\_dns\_config = {<br/>    options = [{ name = "ndots", value = "1" }]<br/>  }<br/><br/>Setting `ndots` lower than the longest bare name you rely on will break that<br/>name's resolution, so if you add your own single-label service references,<br/>either write them as FQDNs or leave this unset.<br/><br/>Nameservers are validated as plain IPv4 or IPv6 addresses, at most 3,<br/>matching the limits the Kubernetes pod spec enforces at admission.<br/><br/>Search domains are validated to Kubernetes' relaxed rules<br/>(RelaxedDNSSearchValidation, on by default since 1.33 and GA in 1.34):<br/>lowercase RFC 1123 subdomains of at most 253 characters, underscores<br/>permitted, and a bare "." accepted. Clusters on 1.32 or older validate<br/>strictly at admission, unless the RelaxedDNSSearchValidation feature<br/>gate is enabled by hand, and reject "." and underscore-containing<br/>domains even though this module's plan accepts them. | <pre>object({<br/>    nameservers = optional(list(string))<br/>    searches    = optional(list(string))<br/>    options = optional(list(object({<br/>      name  = string<br/>      value = optional(string)<br/>    })))<br/>  })</pre> | `null` | no |
 | <a name="input_n8n_domain"></a> [n8n\_domain](#input\_n8n\_domain) | Fully-qualified domain name for n8n (e.g. n8n.example.com). Must match the CN / SAN on the certificate provided via certificate\_arn. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -1721,9 +1721,12 @@ module "n8n" {
 
 The module mounts only the selected key read-only at
 `/etc/n8n/credentials-overwrite/<key>` on main, worker, and webhook-processor
-pods, then sets `CREDENTIALS_OVERWRITE_DATA_FILE` to that file. Passing the
-Secret resource's name attribute also makes the Helm release depend on the
-Secret, so a single apply creates them in the required order.
+pods, then sets `CREDENTIALS_OVERWRITE_DATA_FILE` to that file. That variable
+is n8n's generic `_FILE` suffix, which reads any configuration value from a
+file path, rather than a dedicated setting, so it does not appear by name in
+n8n's environment variable reference. Passing the Secret resource's name
+attribute also makes the Helm release depend on the Secret, so a single apply
+creates them in the required order.
 
 The module accepts the Secret name and key, not the JSON. The payload therefore
 does not enter this module's Helm values or managed resources. If the caller

--- a/docs/helm-chart-coverage.md
+++ b/docs/helm-chart-coverage.md
@@ -28,7 +28,7 @@ This module deploys the [n8n Helm chart](https://github.com/n8n-io/n8n-hosting/t
 | `service.annotations`, `service.main.annotations`, `service.webhookProcessor.annotations`, `service.sessionAffinity` | Not exposed |
 | `ingress.*` | Never set by this module. The module manages its own `kubernetes_ingress_v1` (see `create_ingress`, `ingress_annotations`) outside the chart entirely, rather than through the chart's ingress block |
 | `persistence` | Not exposed. n8n itself is stateless and needs no PVC (see README) |
-| `extraVolumes`, `extraVolumeMounts` | `n8n_extra_volumes` / `n8n_extra_volume_mounts` |
+| `extraVolumes`, `extraVolumeMounts` | `n8n_extra_volumes` / `n8n_extra_volume_mounts`, plus one managed `credentials-overwrite` Secret volume and read-only mount appended when `n8n_credentials_overwrite_secret_ref` is set |
 | `extraContainers`, `extraInitContainers` | Not exposed |
 | `dnsPolicy` | Not exposed; chart default used |
 | `dnsConfig` | `n8n_dns_config` (null = not set, Kubernetes' own `ndots:5` default applies). Setting `options = [{ name = "ndots", value = "1" }]` addresses `ndots:5` search-path amplification: measured 80% DNS query reduction on a 246-pod deployment, see the variable's description |

--- a/locals.tf
+++ b/locals.tf
@@ -443,45 +443,77 @@ locals {
   # default_mode arrives as an octal string and is converted with parseint,
   # because Kubernetes wants the integer. A Terraform number literal cannot do
   # this job: 0644 parses as decimal 644, which is octal 1204.
-  n8n_extra_volumes = [
-    for volume in var.n8n_extra_volumes : merge(
-      { name = volume.name },
-      volume.config_map == null ? {} : {
-        configMap = merge(
-          { name = volume.config_map.name },
-          volume.config_map.default_mode == null ? {} : {
-            defaultMode = parseint(volume.config_map.default_mode, 8)
-          },
-        )
-      },
-      volume.secret == null ? {} : {
-        secret = merge(
-          { secretName = volume.secret.secret_name },
-          volume.secret.default_mode == null ? {} : {
-            defaultMode = parseint(volume.secret.default_mode, 8)
-          },
-        )
-      },
-      volume.persistent_volume_claim == null ? {} : {
-        persistentVolumeClaim = merge(
-          { claimName = volume.persistent_volume_claim.claim_name },
-          volume.persistent_volume_claim.read_only == null ? {} : {
-            readOnly = volume.persistent_volume_claim.read_only
-          },
-        )
-      },
-    )
-  ]
-
-  n8n_extra_volume_mounts = [
-    for mount in var.n8n_extra_volume_mounts : merge(
+  n8n_extra_volumes = concat(
+    [
+      for volume in var.n8n_extra_volumes : merge(
+        { name = volume.name },
+        volume.config_map == null ? {} : {
+          configMap = merge(
+            { name = volume.config_map.name },
+            volume.config_map.default_mode == null ? {} : {
+              defaultMode = parseint(volume.config_map.default_mode, 8)
+            },
+          )
+        },
+        volume.secret == null ? {} : {
+          secret = merge(
+            { secretName = volume.secret.secret_name },
+            volume.secret.default_mode == null ? {} : {
+              defaultMode = parseint(volume.secret.default_mode, 8)
+            },
+          )
+        },
+        volume.persistent_volume_claim == null ? {} : {
+          persistentVolumeClaim = merge(
+            { claimName = volume.persistent_volume_claim.claim_name },
+            volume.persistent_volume_claim.read_only == null ? {} : {
+              readOnly = volume.persistent_volume_claim.read_only
+            },
+          )
+        },
+      )
+    ],
+    var.n8n_credentials_overwrite_secret_ref == null ? [] : [
       {
-        name      = mount.name
-        mountPath = mount.mount_path
-        readOnly  = mount.read_only
+        name = "credentials-overwrite"
+        secret = {
+          secretName = var.n8n_credentials_overwrite_secret_ref.name
+          items = [
+            {
+              key  = var.n8n_credentials_overwrite_secret_ref.key
+              path = var.n8n_credentials_overwrite_secret_ref.key
+            },
+          ]
+        }
       },
-      mount.sub_path == null ? {} : { subPath = mount.sub_path },
-    )
+    ],
+  )
+
+  n8n_extra_volume_mounts = concat(
+    [
+      for mount in var.n8n_extra_volume_mounts : merge(
+        {
+          name      = mount.name
+          mountPath = mount.mount_path
+          readOnly  = mount.read_only
+        },
+        mount.sub_path == null ? {} : { subPath = mount.sub_path },
+      )
+    ],
+    var.n8n_credentials_overwrite_secret_ref == null ? [] : [
+      {
+        name      = "credentials-overwrite"
+        mountPath = "/etc/n8n/credentials-overwrite"
+        readOnly  = true
+      },
+    ],
+  )
+
+  n8n_credentials_overwrite_env = var.n8n_credentials_overwrite_secret_ref == null ? [] : [
+    {
+      name  = "CREDENTIALS_OVERWRITE_DATA_FILE"
+      value = "/etc/n8n/credentials-overwrite/${var.n8n_credentials_overwrite_secret_ref.key}"
+    },
   ]
 
   # ── n8n_extra_env collision guard ──────────────────────────────────────────

--- a/n8n.tf
+++ b/n8n.tf
@@ -792,9 +792,13 @@ resource "helm_release" "n8n" {
 
         # File-based credential overwrites from a caller-managed Secret. The
         # matching volume and read-only mount are assembled in locals.tf and
-        # rendered onto all three n8n pod types below. Keep this before the
-        # caller escape hatch; the input validation rejects both overwrite env
-        # names while this entry is active, so nothing appended later can win.
+        # rendered onto all three n8n pod types below. This is n8n's generic
+        # "<VAR>_FILE" convention (readEnv in @n8n/config), not a dedicated
+        # setting, and readEnv prefers CREDENTIALS_OVERWRITE_DATA over the
+        # _FILE variant wherever it appears in the env list, so Kubernetes'
+        # last-wins ordering is not the whole story here. The input validation
+        # rejects both names in n8n_extra_env while this entry is active for
+        # exactly that reason.
         local.n8n_credentials_overwrite_env,
 
         # Caller-supplied escape hatch, appended last. Kubernetes resolves

--- a/n8n.tf
+++ b/n8n.tf
@@ -790,6 +790,13 @@ resource "helm_release" "n8n" {
           ] : [],
         ) : [],
 
+        # File-based credential overwrites from a caller-managed Secret. The
+        # matching volume and read-only mount are assembled in locals.tf and
+        # rendered onto all three n8n pod types below. Keep this before the
+        # caller escape hatch; the input validation rejects both overwrite env
+        # names while this entry is active, so nothing appended later can win.
+        local.n8n_credentials_overwrite_env,
+
         # Caller-supplied escape hatch, appended last. Kubernetes resolves
         # duplicate env names last-wins, so this would override anything above
         # it; var.n8n_extra_env is validated against local.n8n_managed_env_names

--- a/scripts/check-variable-banners.sh
+++ b/scripts/check-variable-banners.sh
@@ -39,7 +39,7 @@ FILES=(variables.tf outputs.tf)
 # controllers" / "Chart repositories" / "Chart versions", and predated the
 # "External Secrets" section, so this check failed on an unmodified checkout
 # and `task ci` was red on main for everyone.
-VARIABLE_BANNERS=("Common" "Foundation inputs" "EKS cluster" "Ingress" "Nodes" "Cluster controllers" "Chart repositories" "Chart versions" "n8n resource requests and limits" "Execution settings" "Graceful shutdown" "Task runners" "RDS PostgreSQL" "ElastiCache Redis" "S3" "HPA: main pods" "HPA: webhook processor pods" "Observability" "Community packages" "External Secrets" "KEDA: worker pods" "Pod DNS")
+VARIABLE_BANNERS=("Common" "Foundation inputs" "EKS cluster" "Ingress" "Nodes" "Cluster controllers" "Chart repositories" "Chart versions" "n8n resource requests and limits" "Execution settings" "Graceful shutdown" "Task runners" "RDS PostgreSQL" "ElastiCache Redis" "S3" "HPA: main pods" "HPA: webhook processor pods" "Observability" "Community packages" "Credential overwrites" "External Secrets" "KEDA: worker pods" "Pod DNS")
 OUTPUT_BANNERS=("App DNS" "Secrets" "Infrastructure")
 BANNER_LOOSE_RE='^#[[:space:]]+[─—-]'
 BANNER_STRICT_RE='^# ── (.+) ─{2,}$'

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -7229,6 +7229,28 @@ run "credentials_overwrite_secret_ref_wires_custom_key" {
   }
 }
 
+run "credentials_overwrite_secret_ref_appends_after_caller_volumes" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = { name = "n8n-credentials-overwrite" }
+    n8n_extra_volumes                    = [{ name = "custom-nodes", config_map = { name = "custom-nodes" } }]
+    n8n_extra_volume_mounts              = [{ name = "custom-nodes", mount_path = "/opt/n8n-nodes" }]
+  }
+
+  assert {
+    condition = (
+      length(local.n8n_extra_volumes) == 2 &&
+      local.n8n_extra_volumes[0].name == "custom-nodes" &&
+      local.n8n_extra_volumes[1].name == "credentials-overwrite" &&
+      length(local.n8n_extra_volume_mounts) == 2 &&
+      local.n8n_extra_volume_mounts[0].mountPath == "/opt/n8n-nodes" &&
+      local.n8n_extra_volume_mounts[1].mountPath == "/etc/n8n/credentials-overwrite"
+    )
+    error_message = "Caller-supplied volumes and mounts must be preserved in order, with the managed credential overwrite entries appended last."
+  }
+}
+
 run "credentials_overwrite_secret_ref_rejects_invalid_secret_name" {
   command = plan
 

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -7145,6 +7145,199 @@ run "unmounted_extra_volume_warns" {
   expect_failures = [check.extra_volumes_should_be_mounted]
 }
 
+# ── n8n_credentials_overwrite_secret_ref ─────────────────────────────────────
+# The Helm values blob is unknown at plan time under mocked providers, but all
+# three pieces are assembled in locals before that boundary so their exact
+# volume, mount, and environment-variable contract remains testable.
+
+run "credentials_overwrite_secret_ref_defaults_to_null" {
+  command = plan
+
+  assert {
+    condition = (
+      var.n8n_credentials_overwrite_secret_ref == null &&
+      length(local.n8n_credentials_overwrite_env) == 0
+    )
+    error_message = "The credential overwrite Secret reference must default to null and emit no environment variable."
+  }
+}
+
+run "credentials_overwrite_secret_ref_wires_default_key" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = {
+      name = "n8n-credentials-overwrite"
+    }
+  }
+
+  assert {
+    condition = local.n8n_extra_volumes == [
+      {
+        name = "credentials-overwrite"
+        secret = {
+          secretName = "n8n-credentials-overwrite"
+          items = [
+            {
+              key  = "credentials-overwrite.json"
+              path = "credentials-overwrite.json"
+            },
+          ]
+        }
+      },
+    ]
+    error_message = "The managed volume must project only the default credential overwrite key from the caller-managed Secret."
+  }
+
+  assert {
+    condition = local.n8n_extra_volume_mounts == [
+      {
+        name      = "credentials-overwrite"
+        mountPath = "/etc/n8n/credentials-overwrite"
+        readOnly  = true
+      },
+    ]
+    error_message = "The credential overwrite Secret must be mounted read-only at its dedicated directory."
+  }
+
+  assert {
+    condition = (
+      length(local.n8n_credentials_overwrite_env) == 1 &&
+      local.n8n_credentials_overwrite_env[0].name == "CREDENTIALS_OVERWRITE_DATA_FILE" &&
+      local.n8n_credentials_overwrite_env[0].value == "/etc/n8n/credentials-overwrite/credentials-overwrite.json"
+    )
+    error_message = "CREDENTIALS_OVERWRITE_DATA_FILE must point at the projected default key."
+  }
+}
+
+run "credentials_overwrite_secret_ref_wires_custom_key" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = {
+      name = "n8n-credentials-overwrite"
+      key  = "shared_oauth.json"
+    }
+  }
+
+  assert {
+    condition = (
+      local.n8n_extra_volumes[0].secret.items[0].key == "shared_oauth.json" &&
+      local.n8n_credentials_overwrite_env[0].value == "/etc/n8n/credentials-overwrite/shared_oauth.json"
+    )
+    error_message = "A custom Secret key must drive both the projected filename and CREDENTIALS_OVERWRITE_DATA_FILE."
+  }
+}
+
+run "credentials_overwrite_secret_ref_rejects_invalid_secret_name" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = {
+      name = "N8N Credentials"
+    }
+  }
+
+  expect_failures = [var.n8n_credentials_overwrite_secret_ref]
+}
+
+run "credentials_overwrite_secret_ref_rejects_invalid_key" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = {
+      name = "n8n-credentials-overwrite"
+      key  = "nested/credentials.json"
+    }
+  }
+
+  expect_failures = [var.n8n_credentials_overwrite_secret_ref]
+}
+
+run "credentials_overwrite_escape_hatch_remains_valid_when_reference_is_null" {
+  command = plan
+
+  variables {
+    n8n_extra_env = [
+      {
+        name  = "CREDENTIALS_OVERWRITE_DATA_FILE"
+        value = "/existing/credentials-overwrite.json"
+      },
+    ]
+  }
+
+  assert {
+    condition     = var.n8n_extra_env[0].name == "CREDENTIALS_OVERWRITE_DATA_FILE"
+    error_message = "Existing escape-hatch configurations must remain valid while the dedicated Secret reference is unset."
+  }
+}
+
+run "credentials_overwrite_secret_ref_rejects_overwrite_env_conflict" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = {
+      name = "n8n-credentials-overwrite"
+    }
+    n8n_extra_env = [
+      { name = "CREDENTIALS_OVERWRITE_DATA", value = "{}" },
+    ]
+  }
+
+  expect_failures = [var.n8n_credentials_overwrite_secret_ref]
+}
+
+run "credentials_overwrite_secret_ref_rejects_overwrite_file_env_conflict" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = {
+      name = "n8n-credentials-overwrite"
+    }
+    n8n_extra_env = [
+      { name = "CREDENTIALS_OVERWRITE_DATA_FILE", value = "/existing/credentials-overwrite.json" },
+    ]
+  }
+
+  expect_failures = [var.n8n_credentials_overwrite_secret_ref]
+}
+
+run "credentials_overwrite_secret_ref_rejects_volume_name_conflict" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = {
+      name = "n8n-credentials-overwrite"
+    }
+    n8n_extra_volumes = [
+      { name = "credentials-overwrite", secret = { secret_name = "existing-overwrite" } },
+    ]
+    n8n_extra_volume_mounts = [
+      { name = "credentials-overwrite", mount_path = "/existing/credentials-overwrite" },
+    ]
+  }
+
+  expect_failures = [var.n8n_credentials_overwrite_secret_ref]
+}
+
+run "credentials_overwrite_secret_ref_rejects_mount_path_conflict" {
+  command = plan
+
+  variables {
+    n8n_credentials_overwrite_secret_ref = {
+      name = "n8n-credentials-overwrite"
+    }
+    n8n_extra_volumes = [
+      { name = "existing-overwrite", secret = { secret_name = "existing-overwrite" } },
+    ]
+    n8n_extra_volume_mounts = [
+      { name = "existing-overwrite", mount_path = "/etc/n8n/credentials-overwrite" },
+    ]
+  }
+
+  expect_failures = [var.n8n_credentials_overwrite_secret_ref]
+}
+
 # ── n8n_community_packages_registry ───────────────────────────────────────────
 
 run "community_packages_registry_defaults_to_null" {

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -7288,9 +7288,13 @@ run "credentials_overwrite_escape_hatch_remains_valid_when_reference_is_null" {
     ]
   }
 
+  # The plan completing without expect_failures is what proves the validation
+  # leaves the escape hatch alone while the reference is null. The assert adds
+  # the other half: the module emits no CREDENTIALS_OVERWRITE_DATA_FILE of its
+  # own, so the caller's entry is the only one in the rendered env list.
   assert {
-    condition     = var.n8n_extra_env[0].name == "CREDENTIALS_OVERWRITE_DATA_FILE"
-    error_message = "Existing escape-hatch configurations must remain valid while the dedicated Secret reference is unset."
+    condition     = length(local.n8n_credentials_overwrite_env) == 0
+    error_message = "With the Secret reference unset, the module must not emit its own CREDENTIALS_OVERWRITE_DATA_FILE next to the caller's escape-hatch entry."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -2763,6 +2763,83 @@ variable "n8n_extra_env" {
   }
 }
 
+# ── Credential overwrites ────────────────────────────────────────────────────
+
+variable "n8n_credentials_overwrite_secret_ref" {
+  description = <<-EOT
+    Existing Kubernetes Secret containing n8n credential overwrite JSON. The
+    module mounts only the selected key, read-only, at
+    /etc/n8n/credentials-overwrite/<key> on main, worker, and webhook-processor
+    pods and sets CREDENTIALS_OVERWRITE_DATA_FILE to that path. name is the
+    Secret's name in var.namespace; key defaults to
+    "credentials-overwrite.json". The module accepts only this reference and
+    never reads the JSON, so the payload does not enter this module's Helm values
+    or managed resources. If Terraform creates the Secret, its payload can still
+    enter the caller's state.
+
+    n8n reads the file at startup. Updating the caller-managed Secret does not
+    roll pods, and the module cannot add a content checksum without reading the
+    payload into state. After each rotation, manually restart n8n-main,
+    n8n-worker, and n8n-webhook-processor. CREDENTIALS_OVERWRITE_PERSISTENCE is
+    intentionally outside this file-based feature.
+
+    When this input is set, n8n_extra_env may not set
+    CREDENTIALS_OVERWRITE_DATA or CREDENTIALS_OVERWRITE_DATA_FILE,
+    n8n_extra_volumes may not use the reserved name "credentials-overwrite",
+    and n8n_extra_volume_mounts may not use the reserved mount path
+    "/etc/n8n/credentials-overwrite". Null preserves the escape-hatch behavior
+    and rendered Helm values from before this input existed.
+  EOT
+
+  type = object({
+    name = string
+    key  = optional(string, "credentials-overwrite.json")
+  })
+  default = null
+
+  validation {
+    condition = (
+      var.n8n_credentials_overwrite_secret_ref == null ? true :
+      can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.n8n_credentials_overwrite_secret_ref.name))
+      && length(var.n8n_credentials_overwrite_secret_ref.name) <= 253
+    )
+    error_message = "n8n_credentials_overwrite_secret_ref.name must be a DNS-1123 subdomain of 253 characters or fewer, which is what Kubernetes requires of a Secret name: lowercase alphanumerics, hyphens and dots, starting and ending with an alphanumeric, with no empty label (e.g. \"n8n-credentials-overwrite\")."
+  }
+
+  validation {
+    condition = (
+      var.n8n_credentials_overwrite_secret_ref == null ? true :
+      can(regex("^[-._a-zA-Z0-9]+$", var.n8n_credentials_overwrite_secret_ref.key))
+      && length(var.n8n_credentials_overwrite_secret_ref.key) <= 253
+      && !contains([".", ".."], var.n8n_credentials_overwrite_secret_ref.key)
+      && !startswith(var.n8n_credentials_overwrite_secret_ref.key, "..")
+    )
+    error_message = "n8n_credentials_overwrite_secret_ref.key must be a valid Secret key of 253 characters or fewer: alphanumerics, '-', '_' and '.' only, and not \".\", \"..\" or a name starting with \"..\"."
+  }
+
+  validation {
+    condition = var.n8n_credentials_overwrite_secret_ref == null ? true : alltrue([
+      for env in var.n8n_extra_env :
+      !contains(["CREDENTIALS_OVERWRITE_DATA", "CREDENTIALS_OVERWRITE_DATA_FILE"], env.name)
+    ])
+    error_message = "n8n_credentials_overwrite_secret_ref conflicts with CREDENTIALS_OVERWRITE_DATA or CREDENTIALS_OVERWRITE_DATA_FILE in n8n_extra_env. Remove the escape-hatch entry and let the dedicated input set the file path."
+  }
+
+  validation {
+    condition = var.n8n_credentials_overwrite_secret_ref == null ? true : alltrue([
+      for volume in var.n8n_extra_volumes : volume.name != "credentials-overwrite"
+    ])
+    error_message = "n8n_credentials_overwrite_secret_ref reserves the volume name \"credentials-overwrite\". Rename or remove the conflicting n8n_extra_volumes entry."
+  }
+
+  validation {
+    condition = var.n8n_credentials_overwrite_secret_ref == null ? true : alltrue([
+      for mount in var.n8n_extra_volume_mounts : mount.mount_path != "/etc/n8n/credentials-overwrite"
+    ])
+    error_message = "n8n_credentials_overwrite_secret_ref reserves the mount path \"/etc/n8n/credentials-overwrite\". Move or remove the conflicting n8n_extra_volume_mounts entry."
+  }
+}
+
 # ── External Secrets ──────────────────────────────────────────────────────────
 # n8n's own External Secrets feature resolves *workflow credential* values from
 # an external vault at runtime (Settings -> External Secrets in the n8n UI),


### PR DESCRIPTION
## Summary

- add an optional caller-managed Secret reference for credential overwrite JSON
- mount the selected key read-only and set `CREDENTIALS_OVERWRITE_DATA_FILE` on every n8n pod type
- preserve existing escape-hatch configurations while rejecting conflicts when the new input is active
- document manual pod rollouts after Secret rotation

Closes #114.

## Validation

- `terraform validate`
- `terraform test` (546 passed)
- `terraform fmt -check -recursive`
- `tflint --format compact`
- Checkov (383 passed, 0 failed)
- `terraform-docs --output-check .`
- `./scripts/check-variable-banners.sh`
- `git diff --check`