### PR TITLE
docs(readme): correct the customer-managed Redis TLS claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,6 +488,25 @@ this project adheres to the stability contract in
   call for this attribute on its own, and nothing about the running cache
   changes.
 
+### Fixed
+
+- **Docs:** the README's Redis in-transit encryption chapter claimed
+  `create_elasticache = false` was "not compatible" with
+  `redis_transit_encryption_enabled` and that the combination was "rejected at
+  plan time". Neither is true, and it has not been true on any released
+  version. `local.redis_tls_active` reads the input directly on both paths, and
+  `check "redis_tuning_requires_module_managed_elasticache"` (`redis.tf`)
+  deliberately omits it from the inputs it rejects on the customer-managed
+  path, saying in its own message that TLS and AUTH posture there are
+  controlled by `redis_transit_encryption_enabled`, `redis_auth_token` and
+  `redis_username`. `examples/customer-managed-redis` sets exactly this
+  combination, and its test asserts the TLS path is what the example exists to
+  exercise. The section now describes the input's actual meaning on that path:
+  a declaration that the caller's endpoint is TLS-only, which wires n8n and the
+  KEDA triggers to speak TLS without the module terminating or verifying
+  anything. `redis_transit_encryption_mode`, which genuinely does not apply
+  there, is called out separately. No behavior change.
+
 ## [0.3.0] - 2026-08-13
 
 Minor release per the [stability contract](./README.md#stability--versioning):

--- a/README.md
+++ b/README.md
@@ -989,9 +989,10 @@ that your endpoint does. Leave both unset for an endpoint that accepts
 unauthenticated, plaintext connections.
 
 `redis_transit_encryption_mode` is the one TLS input that does not apply here:
-it is a property of the replication group the module manages, and a `check`
-says so when it is set alongside `create_elasticache = false`. Your endpoint's
-own TLS posture is yours to configure.
+it is a property of the replication group the module manages. Leave it at its
+`required` default. Changing it to `preferred` alongside
+`create_elasticache = false` raises a `check` warning. Your endpoint's own TLS
+posture is yours to configure.
 
 See [Customer-managed Redis](#customer-managed-redis), and
 [`examples/customer-managed-redis`](./examples/customer-managed-redis/), which
@@ -1000,8 +1001,9 @@ runs exactly this combination.
 ### Worker autoscaling
 
 Queue-depth autoscaling keeps working with the flag on. Both worker triggers
-gain `enableTLS` and a reference to the AUTH token, so KEDA reads queue depth
-over the same encrypted, authenticated connection the workers use.
+gain `enableTLS`, so KEDA reads queue depth over the same encrypted connection
+the workers use. When AUTH is active, each trigger also gains a reference to
+the AUTH token and uses the same authenticated connection as the workers.
 
 TLS is the half that has to land. Without it KEDA opens a plaintext connection
 to a TLS-only endpoint and hangs on `connection to redis failed: i/o timeout`

--- a/README.md
+++ b/README.md
@@ -978,12 +978,24 @@ queued job goes with it. Drain workers first.
 > `moved` block absorbs the `count` added to the cluster resource, and existing
 > deployments plan `No changes.`
 
-### `create_elasticache = false` is not compatible
+### `create_elasticache = false` makes this a declaration
 
-The module cannot put TLS or a token on a Redis it does not manage, so this
-combination is rejected at plan time rather than applied. Terminate TLS on your
-own endpoint and leave this variable at its default. See
-[Customer-managed Redis](#customer-managed-redis).
+The module provisions nothing to encrypt on that path, so this variable
+declares what your endpoint already requires rather than configuring it. Set it
+to `true` when your Redis is TLS-only: n8n and both KEDA queue-depth triggers
+are wired to speak TLS, and AUTH comes from `redis_auth_token` or
+`redis_auth_token_secret_ref`. The module neither terminates TLS nor verifies
+that your endpoint does. Leave both unset for an endpoint that accepts
+unauthenticated, plaintext connections.
+
+`redis_transit_encryption_mode` is the one TLS input that does not apply here:
+it is a property of the replication group the module manages, and a `check`
+says so when it is set alongside `create_elasticache = false`. Your endpoint's
+own TLS posture is yours to configure.
+
+See [Customer-managed Redis](#customer-managed-redis), and
+[`examples/customer-managed-redis`](./examples/customer-managed-redis/), which
+runs exactly this combination.
 
 ### Worker autoscaling
 


### PR DESCRIPTION
## What

The README's Redis in-transit-encryption chapter claimed `create_elasticache = false` was "not compatible" with `redis_transit_encryption_enabled`, and that the combination was "rejected at plan time." Neither has ever been true.

## Evidence

- `locals.tf`: `redis_tls_active` reads `var.redis_transit_encryption_enabled` unconditionally on both the module-managed and customer-managed paths. Only `redis_managed_tls_active` is gated on `create_elasticache`.
- `redis.tf`, `check "redis_tuning_requires_module_managed_elasticache"`: deliberately omits `redis_transit_encryption_enabled` from the inputs it rejects on the customer-managed path; its own message names that variable as the control for TLS posture there.
- `examples/customer-managed-redis` sets `create_elasticache = false` with `redis_transit_encryption_enabled = true`, and its test asserts the TLS path is exactly what the example exercises.

## Change

Rewrites the section to describe what the input actually means on the customer-managed path: a declaration that the caller's endpoint is TLS-only, which wires n8n and both KEDA queue-depth triggers to speak TLS. The module neither terminates nor verifies TLS itself. Calls out `redis_transit_encryption_mode` separately, since that one genuinely does not apply on that path (it's a property of the replication group the module manages).

Docs only, no behavior change. `CHANGELOG.md` has a matching entry under `Fixed`.

## Verification

- `terraform-docs --output-check .`: `README.md is up to date`.
- `markdownlint README.md`: clean on the edited range (pre-existing errors elsewhere are all inside the generated `BEGIN_TF_DOCS` block, unrelated).